### PR TITLE
Optimize reduce

### DIFF
--- a/src/utils/image/ciede2000.py
+++ b/src/utils/image/ciede2000.py
@@ -12,7 +12,7 @@ def rgb2xyz(rgb):
             c = ((c + 0.055) / 1.055) ** 2.4
         else:
             c = c / 12.92
-        rgb[i] = c*100
+        rgb[i] = c * 100
     xyz = np.zeros((3), dtype=np.float64)
     xyz[0] = rgb[0] * 0.4124 + rgb[1] * 0.3576 + rgb[2] * 0.1805
     xyz[1] = rgb[0] * 0.2126 + rgb[1] * 0.7152 + rgb[2] * 0.0722
@@ -23,7 +23,6 @@ def rgb2xyz(rgb):
 @jit(nopython=True)
 def xyz2lab(xyz):
     """Converts XYZ pixel array to LAB format."""
-    
     xyz[0] = xyz[0] / 95.047
     xyz[1] = xyz[1] / 100.00
     xyz[2] = xyz[2] / 108.883

--- a/src/utils/image/ciede2000.py
+++ b/src/utils/image/ciede2000.py
@@ -5,16 +5,14 @@ from numba import jit
 @jit(nopython=True)
 def rgb2xyz(rgb):
     """Converts RGB pixel array to XYZ format."""
-
-    def format(c):
+    for i in range(3):
+        c = rgb[i]
         c = c / 255.0
         if c > 0.04045:
             c = ((c + 0.055) / 1.055) ** 2.4
         else:
             c = c / 12.92
-        return c * 100
-
-    rgb = list(map(format, rgb))
+        rgb[i] = c*100
     xyz = np.zeros((3), dtype=np.float64)
     xyz[0] = rgb[0] * 0.4124 + rgb[1] * 0.3576 + rgb[2] * 0.1805
     xyz[1] = rgb[0] * 0.2126 + rgb[1] * 0.7152 + rgb[2] * 0.0722
@@ -25,18 +23,17 @@ def rgb2xyz(rgb):
 @jit(nopython=True)
 def xyz2lab(xyz):
     """Converts XYZ pixel array to LAB format."""
-
-    def format(c):
+    
+    xyz[0] = xyz[0] / 95.047
+    xyz[1] = xyz[1] / 100.00
+    xyz[2] = xyz[2] / 108.883
+    for i in range(3):
+        c = xyz[i]
         if c > 0.008856:
             c = c ** (1.0 / 3.0)
         else:
             c = (7.787 * c) + (16.0 / 116.0)
-        return c
-
-    xyz[0] = xyz[0] / 95.047
-    xyz[1] = xyz[1] / 100.00
-    xyz[2] = xyz[2] / 108.883
-    xyz = list(map(format, xyz))
+        xyz[i] = c
     lab = np.zeros((3), dtype=np.float64)
     lab[0] = (116.0 * xyz[1]) - 16.0
     lab[1] = 500.0 * (xyz[0] - xyz[1])

--- a/src/utils/image/ciede2000.py
+++ b/src/utils/image/ciede2000.py
@@ -2,7 +2,7 @@ import numpy as np
 from numba import jit
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def rgb2xyz(rgb):
     """Converts RGB pixel array to XYZ format."""
     for i in range(3):
@@ -20,7 +20,7 @@ def rgb2xyz(rgb):
     return xyz
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def xyz2lab(xyz):
     """Converts XYZ pixel array to LAB format."""
     xyz[0] = xyz[0] / 95.047
@@ -40,14 +40,14 @@ def xyz2lab(xyz):
     return lab
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def rgb2lab(rgb):
     """Convert RGB pixel array into LAB format."""
     return xyz2lab(rgb2xyz(rgb))
 
 
 # from https://github.com/nschloe/colorio/blob/main/src/colorio/diff/_ciede2000.py
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def ciede2000(
     lab1, lab2, k_L: float = 1.0, k_C: float = 1.0, k_H: float = 1.0
 ) -> np.ndarray:

--- a/src/utils/pxls/template.py
+++ b/src/utils/pxls/template.py
@@ -127,7 +127,7 @@ def stylize(style, stylesize, palette, glow_opacity=0):
     return res
 
 
-@jit(nopython=True, locals={"color_bit": types.uint64, "mapped_color_idx": types.uint8})
+@jit(nopython=True, cache=True, locals={"color_bit": types.uint64, "mapped_color_idx": types.uint8})
 def _fast_reduce(array, palette, dist_func):
     cache = Dict.empty(
         key_type=types.uint64,
@@ -140,7 +140,7 @@ def _fast_reduce(array, palette, dist_func):
         j = idx % width
         alpha = array[i, j, 3]
         if alpha > 128:
-            color = array[i , j, :3]
+            color = array[i, j, :3]
             color_bit = (color[0] << 16) + (color[1] << 8) + color[2]
             if color_bit in cache:
                 mapped_color_idx = cache[color_bit]
@@ -185,7 +185,7 @@ def reduce(array: np.array, palette: np.array, matching="fast") -> np.array:
     return res
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def nearest_color_idx_ciede2000(color, palette) -> int:
     """
     Find the nearest color to `color` in `palette` using CIEDE2000.

--- a/src/utils/pxls/template.py
+++ b/src/utils/pxls/template.py
@@ -126,22 +126,22 @@ def stylize(style, stylesize, palette, glow_opacity=0):
         res[i] = cstyle
     return res
 
+
 @jit(nopython=True, locals={"color_bit": types.uint64, "mapped_color_idx": types.uint8})
 def _fast_reduce(array, palette, dist_func):
     cache = Dict.empty(
-    key_type=types.uint64,
-    value_type=types.uint8
+        key_type=types.uint64,
+        value_type=types.uint8
     )
-    
     res = np.empty(array.shape[:2], dtype=np.uint8)
     width = array.shape[1]
-    for idx in range(array.shape[0]*array.shape[1]): 
-        i = idx//width
-        j = idx%width
-        alpha = array[i,j,3]
-        if alpha>128:
-            color = array[i,j,:3]
-            color_bit = (color[0]<<16)+(color[1]<<8)+color[2]
+    for idx in range(array.shape[0] * array.shape[1]):
+        i = idx // width
+        j = idx % width
+        alpha = array[i, j, 3]
+        if alpha > 128:
+            color = array[i , j, :3]
+            color_bit = (color[0] << 16) + (color[1] << 8) + color[2]
             if color_bit in cache:
                 mapped_color_idx = cache[color_bit]
             else:
@@ -151,6 +151,7 @@ def _fast_reduce(array, palette, dist_func):
             mapped_color_idx = 255
         res[i, j] = mapped_color_idx
     return res
+
 
 def reduce(array: np.array, palette: np.array, matching="fast") -> np.array:
     """Convert an image array of RGBA colors to an array of palette index
@@ -170,11 +171,11 @@ def reduce(array: np.array, palette: np.array, matching="fast") -> np.array:
     # convert to array just in case
     palette = np.asarray(palette, dtype=np.uint8)
     array = np.asarray(array, dtype=np.uint8)
-    
+
     # Get rid of the alpha component
-    palette = palette[:,:3]
-    
-    if matching=="fast":
+    palette = palette[:, :3]
+
+    if matching == "fast":
         dist_func = nearest_color_idx_euclidean
     else:
         dist_func = nearest_color_idx_ciede2000
@@ -183,11 +184,12 @@ def reduce(array: np.array, palette: np.array, matching="fast") -> np.array:
     res = _fast_reduce(array, palette, dist_func)
     return res
 
+
 @jit(nopython=True)
 def nearest_color_idx_ciede2000(color, palette) -> int:
     """
     Find the nearest color to `color` in `palette` using CIEDE2000.
-    
+
     Parameters
     ----------
     color: a rgb ndarray of uint8 of shape (3,)
@@ -209,12 +211,12 @@ def nearest_color_idx_ciede2000(color, palette) -> int:
 def nearest_color_idx_euclidean(color, palette) -> int:
     """
     Find the nearest color to `color` in `palette` using the Euclidean distance
-    
+
         Parameters
     ----------
     color: a rgb ndarray of uint8 of shape (3,)
     palette: a rgb ndarray of uint8 of shape (palette_size,3)
-    
+
     """
     distances = np.sum((palette - color)**2, axis=1)
     return np.argmin(distances)
@@ -231,6 +233,7 @@ def fast_templatize(n, m, st, red, style_size):
                     style_size * j : style_size * j + style_size,
                 ] = st[red[i][j]]
     return res
+
 
 def templatize(style: dict, image: Image.Image, glow_opacity=0) -> np.ndarray:
     style_array = style["array"]

--- a/src/utils/pxls/template.py
+++ b/src/utils/pxls/template.py
@@ -3,7 +3,9 @@
 import os
 import numpy as np
 from PIL import Image
-from numba import jit, prange
+from numba import jit
+from numba.core import types
+from numba.typed import Dict
 
 from utils.setup import stats
 from utils.image.image_utils import hex_to_rgb
@@ -124,6 +126,31 @@ def stylize(style, stylesize, palette, glow_opacity=0):
         res[i] = cstyle
     return res
 
+@jit(nopython=True, locals={"color_bit": types.uint64, "mapped_color_idx": types.uint8})
+def _fast_reduce(array, palette, dist_func):
+    cache = Dict.empty(
+    key_type=types.uint64,
+    value_type=types.uint8
+    )
+    
+    res = np.empty(array.shape[:2], dtype=np.uint8)
+    width = array.shape[1]
+    for idx in range(array.shape[0]*array.shape[1]): 
+        i = idx//width
+        j = idx%width
+        alpha = array[i,j,3]
+        if alpha>128:
+            color = array[i,j,:3]
+            color_bit = (color[0]<<16)+(color[1]<<8)+color[2]
+            if color_bit in cache:
+                mapped_color_idx = cache[color_bit]
+            else:
+                mapped_color_idx = dist_func(color, palette)
+                cache[color_bit] = mapped_color_idx
+        else:
+            mapped_color_idx = 255
+        res[i, j] = mapped_color_idx
+    return res
 
 def reduce(array: np.array, palette: np.array, matching="fast") -> np.array:
     """Convert an image array of RGBA colors to an array of palette index
@@ -141,76 +168,36 @@ def reduce(array: np.array, palette: np.array, matching="fast") -> np.array:
     assert matching in matchings, msg
 
     # convert to array just in case
-    palette = np.array(palette)
-    array = np.array(array)
+    palette = np.asarray(palette, dtype=np.uint8)
+    array = np.asarray(array, dtype=np.uint8)
+    
+    # Get rid of the alpha component
+    palette = palette[:,:3]
+    
+    if matching=="fast":
+        dist_func = nearest_color_idx_euclidean
+    else:
+        dist_func = nearest_color_idx_ciede2000
+        palette = np.asarray([rgb2lab(color) for color in palette])
 
-    # convert the colors to integers so it's easier to manipulate
-    # e.g. rgba(32, 64, 128, 255) -> 32*2^16 + 64*2^8 + 128*2^0 + 255*0 = 2113664
-    # note: we ignore the alpha values because we will apply a filter to them later
-    array_int = array.dot(np.array([65536, 256, 1, 0], dtype=np.int32))
-    # remove duplicates to have a list of all the unique colors
-    array_colors = np.unique(array_int)
-
-    # we want to make a color map for each unique color
-    # where the key is the color integer and the value is the palette index
-    # first: we populate the color map with the palette colors
-    palette_int = palette.dot(np.array([65536, 256, 1, 0], dtype=np.int32))
-    color_map = np.full(shape=(256 * 256 * 256), fill_value=255, dtype=np.int32)
-    for i, color in enumerate(palette_int):
-        color_map[color] = i
-
-    # if some colors do not match: we complete the color map finding the nearest color
-    if not np.all(np.isin(array_colors, palette_int)):
-        if matching == "fast":
-            # using the Euclidean distance
-            color_map = get_color_map(array_colors, palette, color_map)
-        elif matching == "accurate":
-            # using CIEDE2000 formula
-            color_map = get_color_map_ciede2000(array_colors, palette, color_map)
-
-    # we apply the color map to the image array so we get an array of palette indexes
-    res_array = color_map[array_int]
-
-    # filter out all the pixels with an alpha value inferior to 128
-    res_array[array[:, :, 3] < 128] = 255  # 255 is the index for transparent pixels
-    return res_array
-
-
-@jit(nopython=True, cache=True)
-def nearest_color(color: int , palette):
-    """Find the nearest color to `color` in `palette` using the Euclidean distance"""
-    red = (color >> 16) & 255
-    green = (color >> 8) & 255
-    blue = color & 255
-    rgb = np.array([red, green, blue], dtype=np.uint8)
-
-    distances = np.sqrt(np.sum((palette[:, :3] - rgb)**2, axis=1))
-    return np.argmin(distances)
-
-
-@jit(nopython=True, cache=True)
-def get_color_map(array_colors, palette, color_map):
-    """Get a color map with the index of the nearest color in the palette"""
-    for color in array_colors:
-        if color_map[color] == 255:
-            color_map[color] = nearest_color(color, palette)
-    return color_map
-
+    res = _fast_reduce(array, palette, dist_func)
+    return res
 
 @jit(nopython=True)
-def nearest_color_ciede2000(color, palette):
-    """Find the nearest color to `color` in `palette` using CIEDE2000."""
-    red = (color >> 16) & 255
-    green = (color >> 8) & 255
-    blue = color & 255
-    rgb = np.array([red, green, blue], dtype=np.uint8)
-    lab = rgb2lab(rgb)
+def nearest_color_idx_ciede2000(color, palette) -> int:
+    """
+    Find the nearest color to `color` in `palette` using CIEDE2000.
+    
+    Parameters
+    ----------
+    color: a rgb ndarray of uint8 of shape (3,)
+    palette: a lab ndarray of shape (palette_size,3)
+    """
+    lab = rgb2lab(color)
 
-    min_distance = 1e6
+    min_distance = np.inf
     nearest_color_idx = -1
-    for i, palette_color in enumerate(palette):
-        palette_rgb = palette_color[:3]
-        palette_lab = rgb2lab(palette_rgb)
+    for i, palette_lab in enumerate(palette):
         distance = ciede2000(lab, palette_lab)
         if distance < min_distance:
             min_distance = distance
@@ -218,16 +205,19 @@ def nearest_color_ciede2000(color, palette):
     return nearest_color_idx
 
 
-@jit(nopython=True, parallel=True)
-def get_color_map_ciede2000(array_colors, palette, color_map):
-    """Get a color map with the index of the nearest color in the palette
-using CIEDE2000"""
-
-    for i in prange(len(array_colors)):
-        color = array_colors[i]
-        if color_map[color] == 255:
-            color_map[color] = nearest_color_ciede2000(color, palette)
-    return color_map
+@jit(nopython=True, cache=True)
+def nearest_color_idx_euclidean(color, palette) -> int:
+    """
+    Find the nearest color to `color` in `palette` using the Euclidean distance
+    
+        Parameters
+    ----------
+    color: a rgb ndarray of uint8 of shape (3,)
+    palette: a rgb ndarray of uint8 of shape (palette_size,3)
+    
+    """
+    distances = np.sum((palette - color)**2, axis=1)
+    return np.argmin(distances)
 
 
 @jit(nopython=True, cache=True)
@@ -241,7 +231,6 @@ def fast_templatize(n, m, st, red, style_size):
                     style_size * j : style_size * j + style_size,
                 ] = st[red[i][j]]
     return res
-
 
 def templatize(style: dict, image: Image.Image, glow_opacity=0) -> np.ndarray:
     style_array = style["array"]


### PR DESCRIPTION
Various improvements to the reduce function with the goal of improving speed and reducing memory usage.
The main architectural changes are:
* Replace the huge numpy color mapping array by a dictionary data structure
* Pre-compute lab palette instead of re-running the conversion every time nearest_color_ciede2000 is called

The benchmarks presented below were run on [the following image](https://static01.nyt.com/images/2021/09/14/science/07CAT-STRIPES/07CAT-STRIPES-mediumSquareAt3X-v2.jpg), using `timeit` and `memit` for profiling:
|               | New     | Old         |
|---------------|---------|-------------|
| fast-time     | 209 ms  | 220 ms      |
| fast-mem      | 241 MiB | 319.43 MiB  |
| accurate-time | 765 ms  | 2230 ms     |
| accurate-mem  | 270 MiB | 1262.61 MiB |

 NB: memory is still being leaked for the accurate method, albeit at a much slower rate than before.