### PR TITLE
Use Discord media proxy urls whenever possible

### DIFF
--- a/src/cogs/clock.py
+++ b/src/cogs/clock.py
@@ -5,7 +5,7 @@ from disnake.ext import commands, tasks
 from PIL import Image
 
 from main import tracked_templates
-from utils.discord_utils import image_to_file
+from utils.discord_utils import get_image_url, image_to_file
 from utils.log import get_logger
 from utils.setup import db_servers, db_stats, db_templates, db_users, stats, ws_client
 from utils.time_converter import local_to_utc
@@ -251,7 +251,7 @@ class Clock(commands.Cog):
                     await db_stats.save_snapshot(
                         snapshot_time.replace(tzinfo=None),
                         await stats.get_canvas_code(),
-                        m.embeds[0].image.url,
+                        get_image_url(m.embeds[0].image),
                     )
                     snapshot_saved = True
 

--- a/src/cogs/pxls_template/layer.py
+++ b/src/cogs/pxls_template/layer.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 from main import tracked_templates
 from utils.arguments_parser import MyParser
-from utils.discord_utils import CreateTemplateView, image_to_file
+from utils.discord_utils import CreateTemplateView, get_image_url, image_to_file
 from utils.pxls.template_manager import Combo, layer
 from utils.setup import stats
 
@@ -80,7 +80,7 @@ class Layer(commands.Cog):
         # save the URL of the image sent to use it to generate templates later
         if isinstance(ctx, disnake.AppCmdInter):
             m = await ctx.original_message()
-        view.template_image_url = m.embeds[0].image.url
+        view.template_image_url = get_image_url(m.embeds[0].image)
         view.message = m
 
 

--- a/src/cogs/pxls_template/place_template.py
+++ b/src/cogs/pxls_template/place_template.py
@@ -13,6 +13,7 @@ from utils.discord_utils import (
     IMAGE_URL_REGEX,
     format_number,
     get_image_from_message,
+    get_image_url,
     image_to_file,
 )
 from utils.image.image_utils import get_builtin_palette
@@ -219,7 +220,7 @@ class PlaceTemplate(commands.Cog):
             m = await ctx.original_message()
 
         # create a template link with the sent image
-        template_image_url = m.embeds[0].image.url
+        template_image_url = get_image_url(m.embeds[0].image)
 
         text = "**HOW TO USE?**\n"
         text += "1. Install [Tapermonkey (Chrome/Opera)](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en) or [Violentmonkey (Firefox)](https://addons.mozilla.org/en-US/firefox/addon/violentmonkey/).\n"

--- a/src/cogs/pxls_template/progress.py
+++ b/src/cogs/pxls_template/progress.py
@@ -23,6 +23,7 @@ from utils.discord_utils import (
     autocomplete_templates,
     autocomplete_user_templates,
     format_number,
+    get_image_url,
     image_to_file,
 )
 from utils.image.image_utils import find_upscale, v_concatenate
@@ -393,7 +394,7 @@ class Progress(commands.Cog):
             m = await ctx.send(files=files, embed=embed)
             if isinstance(ctx, disnake.AppCmdInter):
                 m = await ctx.original_message()
-            template_image_url = m.embeds[0].thumbnail.url
+            template_image_url = get_image_url(m.embeds[0].thumbnail)
             template_url = template.generate_url(template_image_url, default_scale=1)
             view = MoreInfoView(
                 ctx.author,

--- a/src/cogs/pxls_template/template.py
+++ b/src/cogs/pxls_template/template.py
@@ -18,6 +18,7 @@ from utils.discord_utils import (
     autocomplete_builtin_palettes,
     format_number,
     get_image_from_message,
+    get_image_url,
     image_to_file,
 )
 from utils.image.image_utils import get_colors_from_input, remove_white_space
@@ -446,7 +447,7 @@ class Template(commands.Cog):
             upload_time = round(time.time() - start, 3)
 
             # create a template link with the sent image
-            template_image_url = m.embeds[0].thumbnail.url
+            template_image_url = get_image_url(m.embeds[0].thumbnail)
             template_url = make_template_url(
                 template_image_url, img.width, img.height, ox, oy, title
             )

--- a/src/cogs/pxls_template/template_crop.py
+++ b/src/cogs/pxls_template/template_crop.py
@@ -7,7 +7,12 @@ from PIL import Image
 
 from main import tracked_templates
 from utils.arguments_parser import MyParser
-from utils.discord_utils import CreateTemplateView, autocomplete_templates, image_to_file
+from utils.discord_utils import (
+    CreateTemplateView,
+    autocomplete_templates,
+    get_image_url,
+    image_to_file,
+)
 from utils.pxls.template_manager import get_template_from_url, layer, parse_template
 from utils.setup import stats
 
@@ -212,7 +217,7 @@ class TemplateCrop(commands.Cog):
         # save the URL of the image sent to use it to generate templates later
         if isinstance(ctx, disnake.AppCmdInter):
             m = await ctx.original_message()
-        view.template_image_url = m.embeds[0].image.url
+        view.template_image_url = get_image_url(m.embeds[0].image)
         view.message = m
 
 

--- a/src/cogs/utility.py
+++ b/src/cogs/utility.py
@@ -15,6 +15,7 @@ from utils.discord_utils import (
     UserConverter,
     format_number,
     format_table,
+    get_image_url,
     image_to_file,
 )
 from utils.plot_utils import get_theme
@@ -698,7 +699,7 @@ class Utility(commands.Cog):
                     or not msg.embeds[0].timestamp
                 ):
                     continue
-                snapshot_url = msg.embeds[0].image.url
+                snapshot_url = get_image_url(msg.embeds[0].image)
                 datetime = msg.embeds[0].timestamp.replace(tzinfo=None)
                 values.append((datetime, canvas_code, snapshot_url))
                 count += 1

--- a/src/utils/discord_utils.py
+++ b/src/utils/discord_utils.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import re
-import typing
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from io import BytesIO
@@ -16,9 +15,6 @@ from utils.image import PALETTES
 from utils.pxls.template_manager import get_template_from_url, parse_template
 from utils.setup import db_canvas, db_stats, stats
 from utils.utils import get_content, in_executor
-
-if typing.TYPE_CHECKING:
-    from disnake.embeds import _EmbedMediaProxy
 
 STATUS_EMOJIS = {
     "bot": "<a:status_botting:955632660653408266>",
@@ -289,7 +285,7 @@ def get_url(content, accept_emojis=True, accept_templates=True):
     return None
 
 
-def get_image_url(image: _EmbedMediaProxy) -> str:
+def get_image_url(image) -> str:
     return image.proxy_url or image.url
 
 

--- a/src/utils/discord_utils.py
+++ b/src/utils/discord_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import re
+import typing
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from io import BytesIO
@@ -15,6 +16,9 @@ from utils.image import PALETTES
 from utils.pxls.template_manager import get_template_from_url, parse_template
 from utils.setup import db_canvas, db_stats, stats
 from utils.utils import get_content, in_executor
+
+if typing.TYPE_CHECKING:
+    from disnake.embeds import _EmbedMediaProxy
 
 STATUS_EMOJIS = {
     "bot": "<a:status_botting:955632660653408266>",
@@ -213,10 +217,10 @@ async def get_image(
     elif message and len(message.embeds) > 0 and accept_embeds:
         for e in message.embeds:
             if e.image:
-                url = message.embeds[0].image.url
+                url = get_image_url(message.embeds[0].image)
                 break
             elif e.type == "image" and e.url:
-                url = e.url
+                url = get_image_url(e)
 
     # check the message content
     elif url is not None:
@@ -277,12 +281,16 @@ def get_url(content, accept_emojis=True, accept_templates=True):
         if len(results) != 0:
             emoji_id = results[0][2]
             is_animated = results[0][0] == "a"
-            url = "https://cdn.discordapp.com/emojis/{}.{}".format(
+            url = "https://media.discordapp.net/emojis/{}.{}".format(
                 emoji_id, "gif" if is_animated else "png"
             )
             return dict(url=url, type="emoji")
 
     return None
+
+
+def get_image_url(image: _EmbedMediaProxy) -> str:
+    return image.proxy_url or image.url
 
 
 @in_executor()
@@ -442,7 +450,7 @@ async def get_image_from_inter(
     image_file: An image attachment.
     """
     if image_file:
-        image_link = image_file.url
+        image_link = get_image_url(image_file)
     return InterImage(image_link)
 
 


### PR DESCRIPTION
This consists of using an image's proxy_url instead of url when it is available. (It will not be available when the image is not hosted on Discord.)
The Discord media proxy (`media.discordapp.net`) is a better way to access images because it is CORS enabled, so it does not require going through the pxls CORS proxy to access it. It also caches images, so that they can still be accessed a bit after being deleted.
We also switch to using the media proxy when fetching emoji images.