### PR TITLE
Enhance slash command functionality and fix related issues

### DIFF
--- a/src/cogs/blacklist.py
+++ b/src/cogs/blacklist.py
@@ -173,6 +173,7 @@ class Blacklist(commands.Cog):
     @_blacklist.sub_command(name="add", description="Add a user to the blacklist.")
     @commands.is_owner()
     async def _blacklist_add(self, inter, user: disnake.User):
+        await inter.response.defer()
         await self._do_blacklist_add(inter, user)
 
     @_blacklist.sub_command(
@@ -180,11 +181,13 @@ class Blacklist(commands.Cog):
     )
     @commands.is_owner()
     async def _blacklist_remove(self, inter, user: disnake.User):
+        await inter.response.defer()
         await self._do_blacklist_remove(inter, user)
 
     @_blacklist.sub_command(name="list", description="Show all the blacklisted users.")
     @commands.is_owner()
     async def _blacklist_list(self, inter):
+        await inter.response.defer()
         await self._do_blacklist_list(inter)
 
     @commands.slash_command(
@@ -200,6 +203,7 @@ class Blacklist(commands.Cog):
     )
     @commands.check_any(commands.is_owner(), commands.has_permissions(manage_roles=True))
     async def _roleblacklist_add(self, inter, role: disnake.Role):
+        await inter.response.defer()
         await self._do_roleblacklist_add(inter, role)
 
     @_roleblacklist.sub_command(
@@ -207,6 +211,7 @@ class Blacklist(commands.Cog):
     )
     @commands.check_any(commands.is_owner(), commands.has_permissions(manage_roles=True))
     async def _roleblacklist_remove(self, inter):
+        await inter.response.defer()
         await self._do_roleblacklist_remove(inter)
 
 

--- a/src/cogs/blacklist.py
+++ b/src/cogs/blacklist.py
@@ -1,5 +1,5 @@
 import disnake
-from disnake import Team, User
+from disnake import Team
 from disnake.ext import commands
 from disnake.ext.commands.converter import RoleConverter
 from disnake.ext.commands.errors import RoleNotFound
@@ -12,21 +12,9 @@ class Blacklist(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot: commands.Bot = bot
 
-    @commands.group(hidden=True, description="Ban a user from using the bot.")
-    @commands.is_owner()
-    async def blacklist(self, ctx):
-        pass
+    # --- shared helpers (take a resolved user/role object) ---
 
-    @blacklist.command(
-        name="add", description="Add a user to the blacklist.", usage="<user>"
-    )
-    async def blacklist_add(self, ctx, user):
-        # check that the user exists
-        try:
-            user = await UserConverter().convert(ctx, user)
-        except commands.UserNotFound as e:
-            return await ctx.send(f":x: {e}")
-
+    async def _do_blacklist_add(self, ctx, user):
         # check that the user isn't the bot owner
         app_info = await self.bot.application_info()
         if getattr(self.bot, "owner_ids", None):
@@ -56,19 +44,7 @@ class Blacklist(commands.Cog):
             allowed_mentions=no_user_mention,
         )
 
-    @blacklist.command(
-        name="remove",
-        description="Remove a user from the blacklist.",
-        usage="<user>",
-        aliases=["rm"],
-    )
-    async def blacklist_remove(self, ctx, user):
-        # check that the user exists
-        try:
-            user = await UserConverter().convert(ctx, user)
-        except commands.UserNotFound as e:
-            return await ctx.send(f":x: {e}")
-
+    async def _do_blacklist_remove(self, ctx, user):
         # check that the user is actually blacklisted
         no_user_mention = disnake.AllowedMentions(users=False)  # to avoid pinging user
         discord_db_user = await db_users.get_discord_user(user.id)
@@ -87,8 +63,7 @@ class Blacklist(commands.Cog):
             allowed_mentions=no_user_mention,
         )
 
-    @blacklist.command(description="Show all the blacklisted users.", aliases=["ls"])
-    async def list(self, ctx):
+    async def _do_blacklist_list(self, ctx):
         blacklisted_users = await db_users.get_all_blacklisted_users()
         if blacklisted_users is None:
             return await ctx.send("**No users are blacklisted.**")
@@ -98,13 +73,15 @@ class Blacklist(commands.Cog):
                 text += "\t• <@{}>\n".format(user_id)
             await ctx.send(text)
 
-    @commands.group(
-        hidden=True,
-        invoke_without_command=True,
-        description="Show the current blacklist role.",
-    )
-    @commands.check_any(commands.is_owner(), commands.has_permissions(manage_roles=True))
-    async def roleblacklist(self, ctx):
+    async def _do_roleblacklist_add(self, ctx, role):
+        await db_servers.update_blacklist_role(ctx.guild.id, role.id)
+        await ctx.send(f":white_check_mark: Blacklist role set to <@&{role.id}>.")
+
+    async def _do_roleblacklist_remove(self, ctx):
+        await db_servers.update_blacklist_role(ctx.guild.id, None)
+        await ctx.send(":white_check_mark: Blacklist role removed.")
+
+    async def _do_roleblacklist_show(self, ctx):
         # show the current role
         current_role_id = await db_servers.get_blacklist_role(ctx.guild.id)
         if current_role_id is None:
@@ -119,23 +96,118 @@ class Blacklist(commands.Cog):
         else:
             return await ctx.send(f"Current blacklist role: <@&{current_role.id}>.")
 
+    # --- prefix commands ---
+
+    @commands.group(hidden=True, description="Ban a user from using the bot.")
+    @commands.is_owner()
+    async def blacklist(self, ctx):
+        pass
+
+    @blacklist.command(
+        name="add", description="Add a user to the blacklist.", usage="<user>"
+    )
+    async def blacklist_add(self, ctx, user):
+        # check that the user exists
+        try:
+            user = await UserConverter().convert(ctx, user)
+        except commands.UserNotFound as e:
+            return await ctx.send(f":x: {e}")
+
+        await self._do_blacklist_add(ctx, user)
+
+    @blacklist.command(
+        name="remove",
+        description="Remove a user from the blacklist.",
+        usage="<user>",
+        aliases=["rm"],
+    )
+    async def blacklist_remove(self, ctx, user):
+        # check that the user exists
+        try:
+            user = await UserConverter().convert(ctx, user)
+        except commands.UserNotFound as e:
+            return await ctx.send(f":x: {e}")
+
+        await self._do_blacklist_remove(ctx, user)
+
+    @blacklist.command(description="Show all the blacklisted users.", aliases=["ls"])
+    async def list(self, ctx):
+        await self._do_blacklist_list(ctx)
+
+    @commands.group(
+        hidden=True,
+        invoke_without_command=True,
+        description="Show the current blacklist role.",
+    )
+    @commands.check_any(commands.is_owner(), commands.has_permissions(manage_roles=True))
+    async def roleblacklist(self, ctx):
+        await self._do_roleblacklist_show(ctx)
+
     @roleblacklist.command(
         description="Add a blacklist role, any user with this role won't be able to use the bot.",
         usage="<role name|role id|@role>",
     )
+    @commands.check_any(commands.is_owner(), commands.has_permissions(manage_roles=True))
     async def add(self, ctx, role):
         # check that the role exists and save it
         try:
             role = await RoleConverter().convert(ctx, role)
         except RoleNotFound as e:
             return await ctx.send(f":x: {e}")
-        await db_servers.update_blacklist_role(ctx.guild.id, role.id)
-        await ctx.send(f":white_check_mark: Blacklist role set to <@&{role.id}>.")
+        await self._do_roleblacklist_add(ctx, role)
 
     @roleblacklist.command(description="Remove the current blacklist role.")
+    @commands.check_any(commands.is_owner(), commands.has_permissions(manage_roles=True))
     async def remove(self, ctx):
-        await db_servers.update_blacklist_role(ctx.guild.id, None)
-        await ctx.send(":white_check_mark: Blacklist role removed.")
+        await self._do_roleblacklist_remove(ctx)
+
+    # --- slash commands ---
+
+    @commands.slash_command(
+        name="blacklist",
+        default_member_permissions=disnake.Permissions(administrator=True),
+    )
+    async def _blacklist(self, inter):
+        pass
+
+    @_blacklist.sub_command(name="add", description="Add a user to the blacklist.")
+    @commands.is_owner()
+    async def _blacklist_add(self, inter, user: disnake.User):
+        await self._do_blacklist_add(inter, user)
+
+    @_blacklist.sub_command(
+        name="remove", description="Remove a user from the blacklist."
+    )
+    @commands.is_owner()
+    async def _blacklist_remove(self, inter, user: disnake.User):
+        await self._do_blacklist_remove(inter, user)
+
+    @_blacklist.sub_command(name="list", description="Show all the blacklisted users.")
+    @commands.is_owner()
+    async def _blacklist_list(self, inter):
+        await self._do_blacklist_list(inter)
+
+    @commands.slash_command(
+        name="roleblacklist",
+        default_member_permissions=disnake.Permissions(manage_roles=True),
+    )
+    async def _roleblacklist(self, inter):
+        pass
+
+    @_roleblacklist.sub_command(
+        name="add",
+        description="Add a blacklist role, any user with this role won't be able to use the bot.",
+    )
+    @commands.check_any(commands.is_owner(), commands.has_permissions(manage_roles=True))
+    async def _roleblacklist_add(self, inter, role: disnake.Role):
+        await self._do_roleblacklist_add(inter, role)
+
+    @_roleblacklist.sub_command(
+        name="remove", description="Remove the current blacklist role."
+    )
+    @commands.check_any(commands.is_owner(), commands.has_permissions(manage_roles=True))
+    async def _roleblacklist_remove(self, inter):
+        await self._do_roleblacklist_remove(inter)
 
 
 def setup(bot: commands.Bot):

--- a/src/cogs/blacklist.py
+++ b/src/cogs/blacklist.py
@@ -4,7 +4,7 @@ from disnake.ext import commands
 from disnake.ext.commands.converter import RoleConverter
 from disnake.ext.commands.errors import RoleNotFound
 
-from utils.discord_utils import UserConverter
+from utils.discord_utils import UserConverter, get_display_prefix
 from utils.setup import db_servers, db_users
 
 
@@ -81,7 +81,9 @@ class Blacklist(commands.Cog):
         # remove from the blacklist
         await db_users.set_user_blacklist(user.id, False)
         return await ctx.send(
-            ":white_check_mark: <@{}> has been removed from the blacklist.".format(user.id),
+            ":white_check_mark: <@{}> has been removed from the blacklist.".format(
+                user.id
+            ),
             allowed_mentions=no_user_mention,
         )
 
@@ -107,12 +109,12 @@ class Blacklist(commands.Cog):
         current_role_id = await db_servers.get_blacklist_role(ctx.guild.id)
         if current_role_id is None:
             return await ctx.send(
-                f"No blacklist role assigned, use `{ctx.prefix}{ctx.command} add <role>`"
+                f"No blacklist role assigned, use `{get_display_prefix(self.bot)}{ctx.command} add <role>`"
             )
         current_role = ctx.guild.get_role(int(current_role_id))
         if current_role is None:
             return await ctx.send(
-                f"The current blacklist role is invalid, use `{ctx.prefix}{ctx.command} <role>`"
+                f"The current blacklist role is invalid, use `{get_display_prefix(self.bot)}{ctx.command} <role>`"
             )
         else:
             return await ctx.send(f"Current blacklist role: <@&{current_role.id}>.")

--- a/src/cogs/clock.py
+++ b/src/cogs/clock.py
@@ -166,9 +166,7 @@ class Clock(commands.Cog):
 
         logger.debug("All stats updated.")
 
-    @commands.command(hidden=True)
-    @commands.is_owner()
-    async def forceupdate(self, ctx):
+    async def _do_forceupdate(self, ctx):
         try:
             await self._update_stats_data()
         except Exception as e:
@@ -176,6 +174,21 @@ class Clock(commands.Cog):
                 f":x: **An error occurred during the update:**\n ```{type(e).__name__}: {e}```"
             )
         await ctx.send(":white_check_mark: Successfully updated stats")
+
+    @commands.command(hidden=True)
+    @commands.is_owner()
+    async def forceupdate(self, ctx):
+        await self._do_forceupdate(ctx)
+
+    @commands.slash_command(
+        name="forceupdate",
+        default_member_permissions=disnake.Permissions(administrator=True),
+    )
+    @commands.is_owner()
+    async def _forceupdate(self, inter):
+        """Force an update of the stats (owner only)."""
+        await inter.response.defer()
+        await self._do_forceupdate(inter)
 
     @tasks.loop(minutes=5)
     async def update_online_count(self):

--- a/src/cogs/clock.py
+++ b/src/cogs/clock.py
@@ -6,9 +6,17 @@ from disnake.ext import commands, tasks
 from PIL import Image
 
 from main import tracked_templates
-from utils.discord_utils import get_image_url, image_to_file
+from utils.discord_utils import image_to_file
 from utils.log import get_logger
-from utils.setup import db_servers, db_stats, db_templates, db_users, stats, ws_client
+from utils.setup import (
+    db_servers,
+    db_stats,
+    db_templates,
+    db_users,
+    s3compat_app,
+    stats,
+    ws_client,
+)
 from utils.time_converter import local_to_utc
 
 logger = get_logger("clock")
@@ -63,7 +71,7 @@ class Clock(commands.Cog):
             app_info = await self.bot.application_info()
             # checks if owner_ids is set
             if getattr(self.bot, "owner_ids", None):
-                for owner_id in self.bot.owner_ids: 
+                for owner_id in self.bot.owner_ids:
                     tracked_templates.load_progress_admins(owner_id)
             else:
                 owner = app_info.owner
@@ -256,16 +264,28 @@ class Clock(commands.Cog):
                 embed = disnake.Embed(title="Canvas Snapshot", color=0x66C5CC)
                 embed.timestamp = snapshot_time
                 file = await image_to_file(board_img, filename, embed)
-                m = await channel.send(file=file, embed=embed)
+                await channel.send(file=file, embed=embed)
             except Exception as e:
                 logger.exception(f"Failed to send snapshot to channel {channel_id}: {e}")
                 continue
             else:
                 if not snapshot_saved:
+                    canvas_code = await stats.get_canvas_code()
+                    try:
+                        snapshot_url = await s3compat_app.upload_image(
+                            board_img,
+                            {
+                                "canvas_code": f"{canvas_code}",
+                                "snapshot_time": snapshot_time.strftime("%FT%H%M"),
+                            },
+                        )
+                    except Exception as e:
+                        logger.exception(f"Failed to upload snapshot to S3: {e}")
+                        continue
                     await db_stats.save_snapshot(
                         snapshot_time.replace(tzinfo=None),
-                        await stats.get_canvas_code(),
-                        get_image_url(m.embeds[0].image),
+                        canvas_code,
+                        snapshot_url,
                     )
                     snapshot_saved = True
 

--- a/src/cogs/emote.py
+++ b/src/cogs/emote.py
@@ -5,7 +5,12 @@ import disnake
 from disnake.ext import commands
 from PIL import Image
 
-from utils.discord_utils import format_emoji, get_image_from_message, number_emoji
+from utils.discord_utils import (
+    format_emoji,
+    get_display_prefix,
+    get_image_from_message,
+    number_emoji,
+)
 from utils.image.img_to_gif import img_to_animated_gif
 
 
@@ -21,7 +26,7 @@ class Emote(commands.Cog):
     )
     async def emote(self, ctx, subcommand):
         return await ctx.send(
-            f":x: Sub-command {subcommand} is not found\nUsage: `{ctx.prefix}{ctx.command.name} {ctx.command.usage}`"
+            f":x: Sub-command {subcommand} is not found\nUsage: `{get_display_prefix(self.bot)}{ctx.command.name} {ctx.command.usage}`"
         )
 
     @emote.command(
@@ -72,7 +77,11 @@ class Emote(commands.Cog):
                 ":x: You're getting ratelimited by discord, retry again in 20/30 min"
             )
 
-        await ctx.send(":white_check_mark: Successfully added the emoji {}".format(format_emoji(emoji)))
+        await ctx.send(
+            ":white_check_mark: Successfully added the emoji {}".format(
+                format_emoji(emoji)
+            )
+        )
 
     @emote.command(
         usage="<name>",

--- a/src/cogs/emote.py
+++ b/src/cogs/emote.py
@@ -6,6 +6,7 @@ from disnake.ext import commands
 from PIL import Image
 
 from utils.discord_utils import (
+    InterImage,
     format_emoji,
     get_display_prefix,
     get_image_from_message,
@@ -18,29 +19,14 @@ class Emote(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot: commands.Bot = bot
 
-    @commands.group(
-        usage="[add|remove|list|number]",
-        description="Manage the server custom emotes.",
-        aliases=["emoji"],
-        invoke_without_command=True,
-    )
-    async def emote(self, ctx, subcommand):
-        return await ctx.send(
-            f":x: Sub-command {subcommand} is not found\nUsage: `{get_display_prefix(self.bot)}{ctx.command.name} {ctx.command.usage}`"
-        )
+    # --- shared helpers (take a resolved image source/name) ---
 
-    @emote.command(
-        usage="<name> <url|image>",
-        description="""Add the image as a custom emoji.""",
-        help="""\t- `<name>`: name of the emoji to add\n
-                  \t- `<url|image>`: an image URL or an attached image""",
-    )
-    @commands.has_permissions(manage_emojis=True)
-    async def add(self, ctx, name, url=None):
-
+    async def _do_emote_add(self, ctx, name, image_source):
         # get the input image
         try:
-            img_bytes, url = await get_image_from_message(ctx, url, return_type="bytes")
+            img_bytes, url = await get_image_from_message(
+                ctx, image_source, return_type="bytes"
+            )
         except ValueError as e:
             return await ctx.send(f":x: {e}")
 
@@ -83,13 +69,7 @@ class Emote(commands.Cog):
             )
         )
 
-    @emote.command(
-        usage="<name>",
-        description="""Remove a custom emoji from the server.""",
-        aliases=["delete", "rm"],
-    )
-    @commands.has_permissions(manage_emojis=True)
-    async def remove(self, ctx, name):
+    async def _do_emote_remove(self, ctx, name):
         emotes = [x for x in ctx.guild.emojis if x.name == name]
         if len(emotes) == 0:
             return await ctx.send(":x: There is no emote with that name on this server.")
@@ -105,11 +85,7 @@ class Emote(commands.Cog):
         for emote in emotes:
             await emote.delete()
 
-    @emote.command(
-        description="Show all of the server custom emojis and their names.",
-        aliases=["show"],
-    )
-    async def list(self, ctx):
+    async def _do_emote_list(self, ctx):
         emotes = ctx.guild.emojis
         if len(emotes) == 0:
             return await ctx.send(":x: There are no emotes in this server")
@@ -122,19 +98,100 @@ class Emote(commands.Cog):
                 res.append("")
             res[i] += emote_text
 
-        # print(len(res))
-        for msg in res:
-            await ctx.send(msg)
+        # first chunk goes through the normal send (works for both prefix and
+        # slash invocations), any additional chunks go through the channel to
+        # avoid the single-interaction-response constraint
+        await ctx.send(res[0])
+        for msg in res[1:]:
+            await ctx.channel.send(msg)
+
+    async def _do_emote_number(self, ctx):
+        nb_static, nb_anim = await number_emoji(ctx)
+        await ctx.send(
+            f"There are {nb_anim+nb_static} emojis in this server:\n\t- {nb_static} emojis\n\t- {nb_anim} animated emojis"
+        )
+
+    # --- prefix commands ---
+
+    @commands.group(
+        usage="[add|remove|list|number]",
+        description="Manage the server custom emotes.",
+        aliases=["emoji"],
+        invoke_without_command=True,
+    )
+    async def emote(self, ctx, subcommand):
+        return await ctx.send(
+            f":x: Sub-command {subcommand} is not found\nUsage: `{get_display_prefix(self.bot)}{ctx.command.name} {ctx.command.usage}`"
+        )
+
+    @emote.command(
+        usage="<name> <url|image>",
+        description="""Add the image as a custom emoji.""",
+        help="""\t- `<name>`: name of the emoji to add\n
+                  \t- `<url|image>`: an image URL or an attached image""",
+    )
+    @commands.has_permissions(manage_emojis=True)
+    async def add(self, ctx, name, url=None):
+        await self._do_emote_add(ctx, name, url)
+
+    @emote.command(
+        usage="<name>",
+        description="""Remove a custom emoji from the server.""",
+        aliases=["delete", "rm"],
+    )
+    @commands.has_permissions(manage_emojis=True)
+    async def remove(self, ctx, name):
+        await self._do_emote_remove(ctx, name)
+
+    @emote.command(
+        description="Show all of the server custom emojis and their names.",
+        aliases=["show"],
+    )
+    async def list(self, ctx):
+        await self._do_emote_list(ctx)
 
     @emote.command(
         description="Give the number of emojis and animated emojis on the server",
         aliases=["nb"],
     )
     async def number(self, ctx):
-        nb_static, nb_anim = await number_emoji(ctx)
-        await ctx.send(
-            f"There are {nb_anim+nb_static} emojis in this server:\n\t- {nb_static} emojis\n\t- {nb_anim} animated emojis"
-        )
+        await self._do_emote_number(ctx)
+
+    # --- slash commands ---
+
+    @commands.slash_command(
+        name="emote",
+        default_member_permissions=disnake.Permissions(manage_emojis=True),
+    )
+    async def _emote(self, inter):
+        pass
+
+    @_emote.sub_command(name="add", description="Add the image as a custom emoji.")
+    @commands.has_permissions(manage_emojis=True)
+    async def _emote_add(self, inter, name: str, image: InterImage = None):
+        await self._do_emote_add(inter, name, image.url if image else None)
+
+    @_emote.sub_command(
+        name="remove", description="Remove a custom emoji from the server."
+    )
+    @commands.has_permissions(manage_emojis=True)
+    async def _emote_remove(self, inter, name: str):
+        await self._do_emote_remove(inter, name)
+
+    @_emote.sub_command(
+        name="list",
+        description="Show all of the server custom emojis and their names.",
+    )
+    async def _emote_list(self, inter):
+        await inter.response.defer()
+        await self._do_emote_list(inter)
+
+    @_emote.sub_command(
+        name="number",
+        description="Give the number of emojis and animated emojis on the server.",
+    )
+    async def _emote_number(self, inter):
+        await self._do_emote_number(inter)
 
 
 def setup(bot: commands.Bot):

--- a/src/cogs/emote.py
+++ b/src/cogs/emote.py
@@ -169,6 +169,7 @@ class Emote(commands.Cog):
     @_emote.sub_command(name="add", description="Add the image as a custom emoji.")
     @commands.has_permissions(manage_emojis=True)
     async def _emote_add(self, inter, name: str, image: InterImage = None):
+        await inter.response.defer()
         await self._do_emote_add(inter, name, image.url if image else None)
 
     @_emote.sub_command(
@@ -176,6 +177,7 @@ class Emote(commands.Cog):
     )
     @commands.has_permissions(manage_emojis=True)
     async def _emote_remove(self, inter, name: str):
+        await inter.response.defer()
         await self._do_emote_remove(inter, name)
 
     @_emote.sub_command(
@@ -183,7 +185,6 @@ class Emote(commands.Cog):
         description="Show all of the server custom emojis and their names.",
     )
     async def _emote_list(self, inter):
-        await inter.response.defer()
         await self._do_emote_list(inter)
 
     @_emote.sub_command(
@@ -191,6 +192,7 @@ class Emote(commands.Cog):
         description="Give the number of emojis and animated emojis on the server.",
     )
     async def _emote_number(self, inter):
+        await inter.response.defer()
         await self._do_emote_number(inter)
 
 

--- a/src/cogs/help.py
+++ b/src/cogs/help.py
@@ -1,7 +1,7 @@
 import disnake
 from disnake.ext import commands
 
-from utils.discord_utils import get_embed_author
+from utils.discord_utils import get_display_prefix, get_embed_author
 
 TYPES = {
     3: "text",
@@ -107,7 +107,7 @@ class Help(commands.Cog):
 
     def _display_prefix(self):
         """Human-friendly prefix shown in help/usage text (mention dispatch)."""
-        return f"@{self.bot.user.name} "
+        return get_display_prefix(self.bot)
 
     async def send_home_help(self, ctx, author, is_slash):
         """Called when >help or /help is used."""

--- a/src/cogs/help.py
+++ b/src/cogs/help.py
@@ -2,7 +2,6 @@ import disnake
 from disnake.ext import commands
 
 from utils.discord_utils import get_embed_author
-from utils.setup import db_servers
 
 TYPES = {
     3: "text",
@@ -106,6 +105,10 @@ class Help(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot: commands.Bot = bot
 
+    def _display_prefix(self):
+        """Human-friendly prefix shown in help/usage text (mention dispatch)."""
+        return f"@{self.bot.user.name} "
+
     async def send_home_help(self, ctx, author, is_slash):
         """Called when >help or /help is used."""
         if is_slash:
@@ -113,7 +116,7 @@ class Help(commands.Cog):
             prefix = "/"
         else:
             categories = get_bot_mapping(self.bot)
-            prefix = await db_servers.get_prefix(self.bot, ctx)
+            prefix = self._display_prefix()
 
         # create the embed header
         home_emoji = HOME_EMOJI
@@ -174,7 +177,7 @@ class Help(commands.Cog):
             prefix = "/"
         else:
             categories = get_bot_mapping(self.bot)
-            prefix = await db_servers.get_prefix(self.bot, ctx)
+            prefix = self._display_prefix()
 
         category_infos = CATEGORIES[category_name]
         commands = categories[category_name]
@@ -222,12 +225,12 @@ class Help(commands.Cog):
             command_params = get_slash_command_parameters(command)
             description = command.body.description
         else:
-            prefix = ctx.prefix
+            prefix = self._display_prefix()
             command_name = command.qualified_name
             command_usage = command.usage
             command_params = command.help
             description = command.description
-        prefix = "/" if is_slash else ctx.prefix
+        prefix = "/" if is_slash else self._display_prefix()
         emb = disnake.Embed(title=f"**Command {command_name}**", color=EMBED_COLOR)
         emb.set_author(name=ctx.me)
         emb.add_field(
@@ -253,7 +256,7 @@ class Help(commands.Cog):
 
     async def send_group_help(self, ctx, group):
         """Called when ">help <group command> is used."""
-        prefix = ctx.prefix
+        prefix = self._display_prefix()
         emb = disnake.Embed(title=f"**Command {group.name}**", color=EMBED_COLOR)
         emb.set_author(name=ctx.me)
         emb.add_field(

--- a/src/cogs/pixel_art/font.py
+++ b/src/cogs/pixel_art/font.py
@@ -150,7 +150,16 @@ class Font(commands.Cog):
         # send the image(s)
         await ctx.send(files=files)
 
-    @commands.command(description="Show the list of the fonts available.")
+    @commands.slash_command(name="fonts")
+    async def _fonts(self, inter: disnake.AppCmdInter):
+        """Show the list of the fonts available."""
+        await inter.response.defer()
+        await self.fonts(inter)
+
+    @commands.command(name="fonts", description="Show the list of the fonts available.")
+    async def p_fonts(self, ctx):
+        await self.fonts(ctx)
+
     async def fonts(self, ctx):
         fonts = get_all_fonts()
         allowed_fonts = get_allowed_fonts()

--- a/src/cogs/pixel_art/font.py
+++ b/src/cogs/pixel_art/font.py
@@ -2,7 +2,11 @@ import disnake
 from disnake.ext import commands
 
 from utils.arguments_parser import parse_pixelfont_args
-from utils.discord_utils import autocomplete_palette_with_none, image_to_file
+from utils.discord_utils import (
+    autocomplete_palette_with_none,
+    get_display_prefix,
+    image_to_file,
+)
 from utils.font.font_manager import PixelText, get_all_fonts, get_allowed_fonts
 from utils.image.image_utils import get_color
 
@@ -91,7 +95,9 @@ class Font(commands.Cog):
             else:
                 font_color_name, font_rgba = get_color(font_color)
                 if font_rgba is None:
-                    return await ctx.send(f":x: The font color `{font_color}` is invalid.")
+                    return await ctx.send(
+                        f":x: The font color `{font_color}` is invalid."
+                    )
         else:
             font_rgba = None
 
@@ -158,7 +164,9 @@ class Font(commands.Cog):
             else:
                 msg += f"\t• `{font}`\n"
         embed = disnake.Embed(title="Available Fonts", color=0x66C5CC, description=msg)
-        embed.set_footer(text=f"* = available for {ctx.prefix}setfont\n")
+        embed.set_footer(
+            text=f"* = available for {get_display_prefix(self.bot)}setfont\n"
+        )
         return await ctx.send(embed=embed)
 
 

--- a/src/cogs/pixel_art/scale.py
+++ b/src/cogs/pixel_art/scale.py
@@ -10,6 +10,7 @@ from utils.discord_utils import (
     InterImage,
     ResizeView,
     format_number,
+    get_display_prefix,
     get_image_from_message,
     get_urls_from_list,
     image_to_file,
@@ -89,7 +90,7 @@ class Scale(commands.Cog):
             resize_command = (
                 "/resize"
                 if isinstance(ctx, disnake.AppCmdInter)
-                else f"{ctx.prefix}resize"
+                else f"{get_display_prefix(self.bot)}resize"
             )
             msg = f"If your image is NOT a pixel art, use `{resize_command}` instead.\n\n"
             msg += "If it is, make sure that:\n"
@@ -99,7 +100,7 @@ class Scale(commands.Cog):
             downscale_command = (
                 "/downscale image:... pixel-size:..."
                 if isinstance(ctx, disnake.AppCmdInter)
-                else f"{ctx.prefix}downscale <image> <pixel size>"
+                else f"{get_display_prefix(self.bot)}downscale <image> <pixel size>"
             )
             msg += f"\n*Note: If you know the scale factor (how big each pixel is), you can try\n`{downscale_command}`*\n"
 

--- a/src/cogs/pxls/leaderboard.py
+++ b/src/cogs/pxls/leaderboard.py
@@ -6,7 +6,7 @@ from disnake.ext import commands
 
 from cogs.pxls.speed import get_stats_graph
 from utils.arguments_parser import check_ranks, parse_leaderboard_args
-from utils.discord_utils import format_number, image_to_file
+from utils.discord_utils import format_number, get_display_prefix, image_to_file
 from utils.image.image_utils import hex_str_to_int
 from utils.plot_utils import fig2img, get_theme, hex_to_rgba_string
 from utils.pxls.cooldown import get_best_possible
@@ -137,7 +137,7 @@ class PxlsLeaderboard(commands.Cog, name="Pxls Leaderboard"):
             if pxls_user_id is None:
                 is_slash = not isinstance(ctx, commands.Context)
                 cmd_name = "user setname" if is_slash else "setname"
-                prefix = "/" if is_slash else ctx.prefix
+                prefix = "/" if is_slash else get_display_prefix(self.bot)
                 usage_text = f"(You can set your default username with `{prefix}{cmd_name} <username>`)"
                 return await ctx.send(
                     ":x: You need to have a set username to use `!`.\n" + usage_text

--- a/src/cogs/pxls/snapshots.py
+++ b/src/cogs/pxls/snapshots.py
@@ -293,6 +293,7 @@ class Snapshots(commands.Cog):
         commands.is_owner(), commands.has_permissions(manage_channels=True)
     )
     async def _setsnapshots_disable(self, inter):
+        await inter.response.defer()
         await self._do_setsnapshots_disable(inter)
 
     @commands.slash_command(name="snapshot")

--- a/src/cogs/pxls/snapshots.py
+++ b/src/cogs/pxls/snapshots.py
@@ -11,6 +11,7 @@ from utils.arguments_parser import MyParser, valid_datetime_type
 from utils.discord_utils import (
     AuthorView,
     autocomplete_templates,
+    get_display_prefix,
     get_urls_from_list,
     image_to_file,
 )
@@ -170,7 +171,7 @@ class Snapshots(commands.Cog):
         channel_id = await db_servers.get_snapshots_channel(ctx.guild.id)
         if channel_id is None:
             return await ctx.send(
-                f"No snapshots channel set.\nYou can enable automatic canvas snapshots every 15 minutes with: `{ctx.prefix}snapshots setchannel <#channel|here|none>`"
+                f"No snapshots channel set.\nYou can enable automatic canvas snapshots every 15 minutes with: `{get_display_prefix(self.bot)}snapshots setchannel <#channel|here|none>`"
             )
         else:
             return await ctx.send(
@@ -195,7 +196,7 @@ class Snapshots(commands.Cog):
             channel_id = await db_servers.get_snapshots_channel(ctx.guild.id)
             if channel_id is None:
                 return await ctx.send(
-                    f":x: No snapshots channel set\n (use `{ctx.prefix}setsnapshot channel <#channel|here|none>`)"
+                    f":x: No snapshots channel set\n (use `{get_display_prefix(self.bot)}setsnapshot channel <#channel|here|none>`)"
                 )
             else:
                 return await ctx.send("Snapshots are set to <#" + str(channel_id) + ">")
@@ -222,7 +223,11 @@ class Snapshots(commands.Cog):
         else:
             # saves the new channel id in the db
             await db_servers.update_snapshots_channel(ctx.guild.id, channel_id)
-            await ctx.send(":white_check_mark: Snapshots successfully set to <#" + str(channel_id) + ">")
+            await ctx.send(
+                ":white_check_mark: Snapshots successfully set to <#"
+                + str(channel_id)
+                + ">"
+            )
 
     @setsnapshots.command(description="Disable snapshots.", aliases=["unset"])
     @commands.check_any(

--- a/src/cogs/pxls/snapshots.py
+++ b/src/cogs/pxls/snapshots.py
@@ -159,14 +159,9 @@ class Snapshots(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot: commands.Bot = bot
 
-    @commands.group(
-        hidden=True,
-        usage="[setchannel|disable]",
-        description="Send canvas snapshots in a channel every 15min.",
-        aliases=["setsnapshot"],
-        invoke_without_command=True,
-    )
-    async def setsnapshots(self, ctx, args=None):
+    # --- shared helpers ---
+
+    async def _do_setsnapshots_show(self, ctx):
         # display the current channel
         channel_id = await db_servers.get_snapshots_channel(ctx.guild.id)
         if channel_id is None:
@@ -180,17 +175,12 @@ class Snapshots(commands.Cog):
                 + ">.\nUse `>setsnapshot disable` to disable them."
             )
 
-    @setsnapshots.command(
-        usage="[#channel|here|none]",
-        description="Set the channel for the snapshots.",
-        aliases=["setchannel"],
-        help="""- `[#<channel>]`: set the snapshots in the given channel
-                  - `[here]`: send the snapshots in the current channel
-                  - `[none]`: disable the snapshots
-                If no parameter is given, will show the current snapshots channel""",
-    )
-    @commands.is_owner()
-    async def channel(self, ctx, channel=None):
+    async def _do_setsnapshots_channel(self, ctx, channel, disable):
+        if disable:
+            await db_servers.update_snapshots_channel(ctx.guild.id, None)
+            await ctx.send(":white_check_mark: Snapshots won't be sent anymore.")
+            return
+
         if channel is None:
             # displays the current channel if no argument specified
             channel_id = await db_servers.get_snapshots_channel(ctx.guild.id)
@@ -200,23 +190,11 @@ class Snapshots(commands.Cog):
                 )
             else:
                 return await ctx.send("Snapshots are set to <#" + str(channel_id) + ">")
-            # return await ctx.send("you need to give a valid channel")
-        channel_id = 0
-        if len(ctx.message.channel_mentions) == 0:
-            if channel == "here":
-                channel_id = ctx.message.channel.id
-            elif channel == "none":
-                await db_servers.update_snapshots_channel(ctx.guild.id, None)
-                await ctx.send(":white_check_mark: Snapshots won't be sent anymore.")
-                return
-            else:
-                return await ctx.send(":x: You need to give a valid channel.")
-        else:
-            channel_id = ctx.message.channel_mentions[0].id
 
+        channel_id = channel.id
         # checks if the bot has write perms in the snapshots channel
-        channel = await self.bot.fetch_channel(channel_id)
-        if not channel.permissions_for(ctx.guild.me).send_messages:
+        fetched_channel = await self.bot.fetch_channel(channel_id)
+        if not fetched_channel.permissions_for(ctx.guild.me).send_messages:
             await ctx.send(
                 f":x: I don't have permissions to send messages in <#{channel_id}>"
             )
@@ -229,13 +207,93 @@ class Snapshots(commands.Cog):
                 + ">"
             )
 
+    async def _do_setsnapshots_disable(self, ctx):
+        await db_servers.update_snapshots_channel(ctx.guild.id, None)
+        await ctx.send(":white_check_mark: Snapshots won't be sent anymore.")
+
+    # --- prefix commands ---
+
+    @commands.group(
+        hidden=True,
+        usage="[setchannel|disable]",
+        description="Send canvas snapshots in a channel every 15min.",
+        aliases=["setsnapshot"],
+        invoke_without_command=True,
+    )
+    async def setsnapshots(self, ctx, args=None):
+        await self._do_setsnapshots_show(ctx)
+
+    @setsnapshots.command(
+        usage="[#channel|here|none]",
+        description="Set the channel for the snapshots.",
+        aliases=["setchannel"],
+        help="""- `[#<channel>]`: set the snapshots in the given channel
+                  - `[here]`: send the snapshots in the current channel
+                  - `[none]`: disable the snapshots
+                If no parameter is given, will show the current snapshots channel""",
+    )
+    @commands.is_owner()
+    async def channel(self, ctx, channel=None):
+        # parse the here/none/#channel string sub-language into a
+        # resolved channel + disable flag for the shared helper
+        parsed_channel = None
+        disable = False
+        if channel is not None:
+            if len(ctx.message.channel_mentions) == 0:
+                if channel == "here":
+                    parsed_channel = ctx.message.channel
+                elif channel == "none":
+                    disable = True
+                else:
+                    return await ctx.send(":x: You need to give a valid channel.")
+            else:
+                parsed_channel = ctx.message.channel_mentions[0]
+
+        await self._do_setsnapshots_channel(ctx, parsed_channel, disable)
+
     @setsnapshots.command(description="Disable snapshots.", aliases=["unset"])
     @commands.check_any(
         commands.is_owner(), commands.has_permissions(manage_channels=True)
     )
     async def disable(self, ctx):
-        await db_servers.update_snapshots_channel(ctx.guild.id, None)
-        await ctx.send(":white_check_mark: Snapshots won't be sent anymore.")
+        await self._do_setsnapshots_disable(ctx)
+
+    # --- slash commands ---
+
+    @commands.slash_command(
+        name="setsnapshots",
+        default_member_permissions=disnake.Permissions(administrator=True),
+    )
+    async def _setsnapshots(self, inter):
+        pass
+
+    @_setsnapshots.sub_command(
+        name="channel", description="Set the channel for the snapshots."
+    )
+    @commands.is_owner()
+    async def _setsnapshots_channel(
+        self,
+        inter,
+        channel: disnake.TextChannel = None,
+        disable: bool = False,
+    ):
+        """
+        Set the channel for the snapshots.
+
+        Parameters
+        ----------
+        channel: The channel to send the snapshots in. If not given, shows the current channel.
+        disable: Disable the automatic snapshots.
+        """
+        await inter.response.defer()
+        await self._do_setsnapshots_channel(inter, channel, disable)
+
+    @_setsnapshots.sub_command(name="disable", description="Disable snapshots.")
+    @commands.check_any(
+        commands.is_owner(), commands.has_permissions(manage_channels=True)
+    )
+    async def _setsnapshots_disable(self, inter):
+        await self._do_setsnapshots_disable(inter)
 
     @commands.slash_command(name="snapshot")
     async def _snapshot(

--- a/src/cogs/pxls/speed.py
+++ b/src/cogs/pxls/speed.py
@@ -5,7 +5,7 @@ import plotly.graph_objects as go
 from disnake.ext import commands
 
 from utils.arguments_parser import parse_speed_args
-from utils.discord_utils import format_number, image_to_file
+from utils.discord_utils import format_number, get_display_prefix, image_to_file
 from utils.image.image_utils import hex_str_to_int, v_concatenate
 from utils.plot_utils import add_glow, fig2img, get_theme, hex_to_rgba_string
 from utils.pxls.cooldown import get_best_possible
@@ -116,7 +116,7 @@ class PxlsSpeed(commands.Cog):
         pxls_user_id = discord_user["pxls_user_id"]
         is_slash = not isinstance(ctx, commands.Context)
         cmd_name = "user setname" if is_slash else "setname"
-        prefix = "/" if is_slash else ctx.prefix
+        prefix = "/" if is_slash else get_display_prefix(self.bot)
         usage_text = f"(Use {'`/speed usernames:<your name>`' if is_slash else f'`{prefix}speed <your name>`'} or you can set your default name with `{prefix}{cmd_name} <your name>`)"
 
         if usernames is None:

--- a/src/cogs/pxls/stats.py
+++ b/src/cogs/pxls/stats.py
@@ -13,6 +13,7 @@ from utils.discord_utils import (
     UserinfoView,
     autocomplete_pxls_name,
     format_number,
+    get_display_prefix,
     image_to_file,
 )
 from utils.plot_utils import matplotlib_to_plotly
@@ -242,7 +243,7 @@ class PxlsStats(commands.Cog):
             if pxls_user_id is None:
                 is_slash = not isinstance(ctx, commands.Context)
                 cmd_name = "user setname" if is_slash else "setname"
-                prefix = "/" if is_slash else ctx.prefix
+                prefix = "/" if is_slash else get_display_prefix(self.bot)
                 return await ctx.send(
                     f":x: You need to specify a pxls username.\n(You can set your default username with `{prefix}{cmd_name} <username>`)"
                 )

--- a/src/cogs/pxls/user_manager.py
+++ b/src/cogs/pxls/user_manager.py
@@ -10,6 +10,7 @@ from utils.discord_utils import (
     UserConverter,
     autocomplete_log_canvases,
     autocomplete_pxls_name,
+    get_display_prefix,
 )
 from utils.font.font_manager import DEFAULT_FONT, get_all_fonts, get_allowed_fonts
 from utils.image.image_utils import hex_str_to_int
@@ -52,7 +53,9 @@ class UserManager(commands.Cog):
         if pxls_user_id is None:
             return await ctx.send(":x: Can't find this pxls username.")
         await db_users.set_pxls_user(ctx.author.id, pxls_user_id)
-        await ctx.send(f":white_check_mark: Pxls username successfully set to **{username}**.")
+        await ctx.send(
+            f":white_check_mark: Pxls username successfully set to **{username}**."
+        )
 
     @user.sub_command(name="unsetname")
     async def _unsetname(self, inter: disnake.AppCmdInter):
@@ -103,9 +106,7 @@ class UserManager(commands.Cog):
 
         if theme is None:
             if isinstance(ctx, commands.Context):
-                set_theme_text = (
-                    f"\n*Use `{ctx.prefix }theme <theme name>` to change your theme.*"
-                )
+                set_theme_text = f"\n*Use `{get_display_prefix(self.bot)}theme <theme name>` to change your theme.*"
             else:
                 set_theme_text = (
                     "\n*Use `/user settheme <theme name>` to change your theme.*"
@@ -166,7 +167,7 @@ class UserManager(commands.Cog):
 
         discord_user = await db_users.get_discord_user(user.id)
         is_slash = not isinstance(ctx, commands.Context)
-        prefix = "/" if is_slash else ctx.prefix
+        prefix = "/" if is_slash else get_display_prefix(self.bot)
         # get the pxls username
         if discord_user["pxls_user_id"] is None:
             cmd_name = "user setname" if is_slash else "setname"
@@ -428,9 +429,7 @@ class UserManager(commands.Cog):
                 color=disnake.Color.green(),
                 description=f":white_check_mark: Log key for canvas `{canvas_code}` successfully {'updated' if is_update else 'added'}.",
             )
-            embed.set_author(
-                name=modal_inter.author
-            )
+            embed.set_author(name=modal_inter.author)
             await modal_inter.response.send_message(embed=embed, ephemeral=True)
 
     @user.sub_command(name="keys")
@@ -442,7 +441,7 @@ class UserManager(commands.Cog):
     @commands.command(name="keys", description="Check the status of your log keys.")
     async def p_keys(self, ctx):
         await self.keys(ctx)
-    
+
     async def keys(self, ctx):
         canvases_with_logs = await db_canvas.get_logs_canvases()
         res = []
@@ -455,17 +454,17 @@ class UserManager(commands.Cog):
             res.append(f"{STATUS_EMOJIS.get(status)} `c{canvas_code}`")
         if not res:
             return await ctx.send("You haven't added any log keys yet.")
-        
+
         coming_fields = []
         current_field = ""
-        for line in res: 
+        for line in res:
             if len(current_field) + len(line) + 1 > 1024:
                 coming_fields.append(current_field)
                 current_field = line
             else:
                 if current_field:
-                    current_field += f"\n{line}" 
-                else: 
+                    current_field += f"\n{line}"
+                else:
                     current_field = line
         coming_fields.append(current_field)
 
@@ -477,12 +476,16 @@ class UserManager(commands.Cog):
         columns = ["", "", ""]
         for i, line in enumerate(res):
             col_index = i % 3
-            if (len(columns[col_index]) + len(line) + 1) > 1024 or \
-                (total_chars + len(line) + 1 > 6000) or \
-                (len(current_embed.fields) >= 25):
+            if (
+                (len(columns[col_index]) + len(line) + 1) > 1024
+                or (total_chars + len(line) + 1 > 6000)
+                or (len(current_embed.fields) >= 25)
+            ):
                 for col_text in columns:
                     if col_text:
-                        current_embed.add_field(name="\u200b", value=col_text, inline=True)
+                        current_embed.add_field(
+                            name="\u200b", value=col_text, inline=True
+                        )
                 coming_embeds.append(current_embed)
                 current_embed = disnake.Embed(color=0x66C5CC).set_author(name=ctx.author)
                 total_chars = 0
@@ -493,15 +496,17 @@ class UserManager(commands.Cog):
             if col_text:
                 if len(current_embed.fields) >= 25:
                     coming_embeds.append(current_embed)
-                    current_embed = disnake.Embed(color=0x66C5CC).set_author(name=ctx.author)
+                    current_embed = disnake.Embed(color=0x66C5CC).set_author(
+                        name=ctx.author
+                    )
                 current_embed.add_field(name="\u200b", value=col_text, inline=True)
 
         coming_embeds.append(current_embed)
         coming_embeds[-1].add_field(
-                name="Key Status",
-                value=f"{STATUS_EMOJIS['online']} = `key added` {STATUS_EMOJIS['offline']} = `key not added`",
-                inline=False,
-                    )
+            name="Key Status",
+            value=f"{STATUS_EMOJIS['online']} = `key added` {STATUS_EMOJIS['offline']} = `key not added`",
+            inline=False,
+        )
         sent_messages = None
         slash = isinstance(ctx, disnake.AppCmdInter)
         for embed in coming_embeds:
@@ -512,7 +517,6 @@ class UserManager(commands.Cog):
                     sent_messages = await ctx.send(embed=embed)
                 else:
                     sent_messages = await sent_messages.reply(embed=embed)
-
 
     @user.sub_command(name="unsetkey")
     async def _unsetkey(
@@ -543,7 +547,9 @@ class UserManager(commands.Cog):
             for canvas_code in canvases:
                 await db_users.delete_key(ctx.author.id, canvas_code)
 
-            return await ctx.send(":white_check_mark: All your log keys were successfully deleted.")
+            return await ctx.send(
+                ":white_check_mark: All your log keys were successfully deleted."
+            )
         else:
             canvas_code = check_canvas_code(canvas_code_input)
             if canvas_code is None:

--- a/src/cogs/pxls/user_manager.py
+++ b/src/cogs/pxls/user_manager.py
@@ -312,7 +312,7 @@ class UserManager(commands.Cog):
         if isinstance(inter, disnake.AppCmdInter):
             usage = "/placemap canvas-code:<the canvas you want>"
         else:
-            usage = f"{inter.prefix}placemap <canvas code>"
+            usage = f"{get_display_prefix(self.bot)}placemap <canvas code>"
         info_embed.add_field(name="How does this work?", value=instructions)
         info_embed.add_field(
             name="Now how do I get my placemaps?",

--- a/src/cogs/pxls_template/layer.py
+++ b/src/cogs/pxls_template/layer.py
@@ -10,7 +10,7 @@ from main import tracked_templates
 from utils.arguments_parser import MyParser
 from utils.discord_utils import CreateTemplateView, get_image_url, image_to_file
 from utils.pxls.template_manager import Combo, layer
-from utils.setup import stats, s3compat_app
+from utils.setup import s3compat_app, stats
 
 
 class Layer(commands.Cog):
@@ -76,7 +76,15 @@ class Layer(commands.Cog):
         metadata = {
             "discord_id": f"{ctx.author.id}",
         }
-        template_image_url = await s3compat_app.upload_image(img, metadata)
+        try:
+            template_image_url = await s3compat_app.upload_image(img, metadata)
+        except ValueError as e:
+            return await ctx.send(f":x: {e}")
+        except Exception as e:
+            print(e)
+            return await ctx.send(
+                ":x: An error occurred while uploading the image to s3compat, please try again later."
+            )
         embed.set_image(url=template_image_url)
 
         # Use the combo object here because it doesn't generate a placeable mask

--- a/src/cogs/pxls_template/progress.py
+++ b/src/cogs/pxls_template/progress.py
@@ -9,8 +9,8 @@ import aiohttp
 import disnake
 import numpy as np
 import pandas as pd
-from disnake.ext import commands
 from disnake import Team, User
+from disnake.ext import commands
 from PIL import Image
 
 from cogs.pxls.speed import get_grouped_graph, get_stats_graph
@@ -26,6 +26,7 @@ from utils.discord_utils import (
     autocomplete_templates,
     autocomplete_user_templates,
     format_number,
+    get_display_prefix,
     get_image_url,
     image_to_file,
 )
@@ -84,7 +85,7 @@ class Progress(commands.Cog):
                 await self.p_check(ctx, template, display)
         else:
             await ctx.send(
-                f"Usage: `{ctx.prefix}{self.progress.qualified_name} {self.progress.usage}`\n*(Use `{ctx.prefix}help {self.progress.qualified_name}` for more information)*"
+                f"Usage: `{get_display_prefix(self.bot)}{self.progress.qualified_name} {self.progress.usage}`\n*(Use `{get_display_prefix(self.bot)}help {self.progress.qualified_name}` for more information)*"
             )
 
     display_options = {
@@ -559,7 +560,8 @@ class Progress(commands.Cog):
         total_pixels = format_number(int(template.total_size))
 
         embed = disnake.Embed(
-            title=f":white_check_mark: Template `{name}` added to the tracker.", color=0x66C5CC
+            title=f":white_check_mark: Template `{name}` added to the tracker.",
+            color=0x66C5CC,
         )
         embed.description = f"**Title**: {template.title or '`N/A`'}\n"
         embed.description += f"[Template link]({template.url})\n"
@@ -1043,7 +1045,8 @@ class Progress(commands.Cog):
         except ValueError as e:
             return await ctx.send(f":x: {e}")
         embed = disnake.Embed(
-            title=f"**:white_check_mark: Template {old_temp.name} Updated**", color=0x66C5CC
+            title=f"**:white_check_mark: Template {old_temp.name} Updated**",
+            color=0x66C5CC,
         )
 
         # Show name update
@@ -1886,8 +1889,8 @@ class Progress(commands.Cog):
 • Managers can only be added/deleted by the template owner.
 • You can see the managers of a template if you click the down arrow on `>progress check`
 • You can see the templates you can manage with `>progress list -filter managed`"""
-        msg = f"```{ctx.prefix}{self.manager.qualified_name} {self.manager.usage}```\n"
-        msg += f"*(Use `{ctx.prefix}help {self.manager.qualified_name}` for more information)*"
+        msg = f"```{get_display_prefix(self.bot)}{self.manager.qualified_name} {self.manager.usage}```\n"
+        msg += f"*(Use `{get_display_prefix(self.bot)}help {self.manager.qualified_name}` for more information)*"
         embed = disnake.Embed(title="Progress Manager", color=0x66C5CC)
         embed.add_field(name="Information", value=help, inline=False)
         embed.add_field(name="Usage", value=msg, inline=False)

--- a/src/cogs/pxls_template/progress.py
+++ b/src/cogs/pxls_template/progress.py
@@ -1532,6 +1532,7 @@ class Progress(commands.Cog):
     @commands.is_owner()
     async def _reload_admins(self, inter):
         """Update the list of progress admins (owner only)."""
+        await inter.response.defer()
         await self._do_reload_admins(inter)
 
     @_progress.sub_command(name="timelapse")

--- a/src/cogs/pxls_template/progress.py
+++ b/src/cogs/pxls_template/progress.py
@@ -1906,21 +1906,50 @@ class Progress(commands.Cog):
 
         await ctx.send(embed=embed)
 
+    async def _resolve_users(self, inter: disnake.AppCmdInter, users_str: str) -> list:
+        """Split ``users_str`` on whitespace and/or commas and resolve each token to
+        a :class:`disnake.User` (mirrors the prefix commands' resolution behavior).
+
+        Tokens that don't resolve to a user are skipped and reported back to the
+        invoker instead of raising."""
+        tokens = [token for token in re.split(r"[\s,]+", users_str.strip()) if token]
+
+        resolved_users = []
+        not_found = []
+        for token in tokens:
+            try:
+                user = await UserConverter().convert(inter, token)
+            except commands.UserNotFound:
+                not_found.append(token)
+            else:
+                resolved_users.append(user)
+
+        if not_found:
+            await inter.send(
+                ":x: Could not find the following user(s): " + ", ".join(not_found)
+            )
+        return resolved_users
+
     @_manager.sub_command(name="add")
     async def _manager_add(
         self,
         inter: disnake.AppCmdInter,
         template: str = commands.Param(autocomplete=autocomplete_user_templates),
-        user: disnake.User = commands.Param(),
+        users: str = commands.Param(
+            description="space- or comma-separated users (mention or ID)"
+        ),
     ):
-        """Add a manager to a template (so they can update the template).
+        """Add managers to a template (so they can update the template).
 
         Parameters
         ----------
         template: The name of the template you want to add managers.
-        user: The user you want to add as manager (a manager can update and rename the template)."""
+        users: The user(s) you want to add as manager (space- or comma-separated mentions or IDs)."""
         await inter.response.defer()
-        await self.manager_add(inter, template, [user])
+        resolved_users = await self._resolve_users(inter, users)
+        if not resolved_users:
+            return await inter.send(":x: No valid user found.")
+        await self.manager_add(inter, template, resolved_users)
 
     @manager.command(
         name="add",
@@ -1988,16 +2017,21 @@ class Progress(commands.Cog):
         self,
         inter: disnake.AppCmdInter,
         template: str = commands.Param(autocomplete=autocomplete_user_templates),
-        user: disnake.User = commands.Param(),
+        users: str = commands.Param(
+            description="space- or comma-separated users (mention or ID)"
+        ),
     ):
-        """Delete a manager from a template.
+        """Delete managers from a template.
 
         Parameters
         ----------
         template: The name of the template you want to delete managers.
-        user: The user you want to delete from the managers."""
+        users: The user(s) you want to delete from the managers (space- or comma-separated mentions or IDs)."""
         await inter.response.defer()
-        await self.manager_delete(inter, template, [user])
+        resolved_users = await self._resolve_users(inter, users)
+        if not resolved_users:
+            return await inter.send(":x: No valid user found.")
+        await self.manager_delete(inter, template, resolved_users)
 
     @manager.command(
         name="delete",

--- a/src/cogs/pxls_template/progress.py
+++ b/src/cogs/pxls_template/progress.py
@@ -1500,13 +1500,7 @@ class Progress(commands.Cog):
 
         await ctx.send(embed=embed, file=res_file)
 
-    @progress.command(
-        hidden=True,
-        description="Update the list of progress admins (owner only)",
-        aliases=["rladmins", "updateadmins"],
-    )
-    @commands.is_owner()
-    async def reload_admins(self, ctx: commands.Context):
+    async def _do_reload_admins(self, ctx):
         app_info = await self.bot.application_info()
         # checks if owner_ids is set
         if getattr(self.bot, "owner_ids", None):
@@ -1524,6 +1518,21 @@ class Progress(commands.Cog):
         for admin_id in admins:
             msg += f"- <@{admin_id}>\n"
         await ctx.send(embed=disnake.Embed(description=msg, color=0x66C5CC))
+
+    @progress.command(
+        hidden=True,
+        description="Update the list of progress admins (owner only)",
+        aliases=["rladmins", "updateadmins"],
+    )
+    @commands.is_owner()
+    async def reload_admins(self, ctx: commands.Context):
+        await self._do_reload_admins(ctx)
+
+    @_progress.sub_command(name="reload-admins")
+    @commands.is_owner()
+    async def _reload_admins(self, inter):
+        """Update the list of progress admins (owner only)."""
+        await self._do_reload_admins(inter)
 
     @_progress.sub_command(name="timelapse")
     async def _timelapse(

--- a/src/cogs/pxls_template/template.py
+++ b/src/cogs/pxls_template/template.py
@@ -108,7 +108,8 @@ class TemplateView(AuthorView):
         # confirmation message (because we HAVE to respond something to the modal inter)
         await modal_inter.response.send_message(
             embed=disnake.Embed(
-                color=0x66C5CC, title=":white_check_mark: Template title successfully added."
+                color=0x66C5CC,
+                title=":white_check_mark: Template title successfully added.",
             ),
             ephemeral=True,
         )
@@ -196,7 +197,9 @@ class Template(commands.Cog):
         parser.add_argument("-glow", action="store_true", default=False)
         parser.add_argument("-ox", action="store", required=False)
         parser.add_argument("-oy", action="store", required=False)
-        parser.add_argument("-host", choices=["s3compat", "discord", "imgur"], default="s3compat")
+        parser.add_argument(
+            "-host", choices=["s3compat", "discord", "imgur"], default="s3compat"
+        )
         parser.add_argument("-nocrop", action="store_true", default=False)
         parser.add_argument("-matching", choices=["fast", "accurate"], required=False)
         parser.add_argument("-palette", action="store", nargs="*")
@@ -411,7 +414,7 @@ class Template(commands.Cog):
                         ":x: An error occurred while uploading the image to imgur, please try again with an other host."
                     )
                     return False
-            elif host == 's3compat':
+            elif host == "s3compat":
                 if not pxls_user_id:
                     await ctx.send(
                         ":x: Sorry, file uploads to S3compat is only available to users who have linked their pxls account with >setname."
@@ -424,7 +427,9 @@ class Template(commands.Cog):
                         "pxls_user_id": f"{pxls_user_id}",
                         "canvas_code": f"{canvas_code}",
                     }
-                    template_image_url = await s3compat_app.upload_image(template_image, metadata)
+                    template_image_url = await s3compat_app.upload_image(
+                        template_image, metadata
+                    )
                 except ValueError as e:
                     await ctx.send(f":x: {e}")
                     return False
@@ -479,7 +484,9 @@ class Template(commands.Cog):
 
             # update the embed with the link in a new field
             embed.add_field(name="**Template Link**", value=template_url, inline=False)
-            warning = ":warning: Warning: if you delete this message the template WILL break."
+            warning = (
+                ":warning: Warning: if you delete this message the template WILL break."
+            )
             embed.set_footer(
                 text="⏲️ Generated in {}s | Uploaded in {}s\n{}".format(
                     processing_time, upload_time, warning
@@ -491,11 +498,20 @@ class Template(commands.Cog):
             await m.edit(embed=embed, view=view)
             return True
 
+    @commands.slash_command(name="styles")
+    async def _styles(self, inter: disnake.AppCmdInter):
+        """List the template styles available."""
+        await inter.response.defer()
+        await self.styles(inter)
+
     @commands.command(
         name="styles",
         description="List the template styles available.",
         aliases=["style"],
     )
+    async def p_styles(self, ctx):
+        await self.styles(ctx)
+
     async def styles(self, ctx):
         styles_available = "**Available Styles:**\n"
         for s in STYLES:

--- a/src/cogs/reddit/reddit.py
+++ b/src/cogs/reddit/reddit.py
@@ -95,16 +95,34 @@ class Reddit(commands.Cog, name="Image"):
                 submission_url, image_url, title, subreddit_name, ex_time
             )
             await ctx.send(embed=embed)
-        except Exception: 
-            await ctx.send(":x: Failed to query reddit for an image. We're possibly being blocked :-()")
+        except Exception:
+            await ctx.send(
+                ":x: Failed to query reddit for an image. We're possibly being blocked :-()"
+            )
+
+    @commands.cooldown(1, 2)
+    @commands.slash_command(name="kitten", description="Send a random kitten image.")
+    async def _kitten(self, inter):
+        await inter.response.defer()
+        subreddit = random.choice(["tuckedinkitties", "kitten"])
+        await self.send_random_image(inter, subreddit, "Here, have a kitten!")
 
     @commands.cooldown(1, 2)
     @commands.command(
-        aliases=["kitty", "neko", "cat"], description="Send a random kitten image.", ratelimit=1
+        aliases=["kitty", "neko", "cat"],
+        description="Send a random kitten image.",
+        ratelimit=1,
     )
     async def kitten(self, ctx):
         subreddit = random.choice(["tuckedinkitties", "kitten"])
         await self.send_random_image(ctx, subreddit, "Here, have a kitten!")
+
+    @commands.cooldown(1, 2)
+    @commands.slash_command(name="duck", description="Send a random duck image.")
+    async def _duck(self, inter):
+        await inter.response.defer()
+        subreddit = "duck"
+        await self.send_random_image(inter, subreddit, "quack quack")
 
     @commands.cooldown(1, 2)
     @commands.command(description="Send a random duck image.")
@@ -113,16 +131,37 @@ class Reddit(commands.Cog, name="Image"):
         await self.send_random_image(ctx, subreddit, "quack quack")
 
     @commands.cooldown(1, 2)
+    @commands.slash_command(name="bird", description="Send a random bird image.")
+    async def _bird(self, inter):
+        await inter.response.defer()
+        subreddit = random.choice(["birding", "birdpics"])
+        await self.send_random_image(inter, subreddit, "Here, have a bird!")
+
+    @commands.cooldown(1, 2)
     @commands.command(description="Send a random bird image.")
     async def bird(self, ctx):
         subreddit = random.choice(["birding", "birdpics"])
         await self.send_random_image(ctx, subreddit, "Here, have a bird!")
 
     @commands.cooldown(1, 2)
+    @commands.slash_command(name="snek", description="Send a random snek image.")
+    async def _snek(self, inter):
+        await inter.response.defer()
+        subreddit = "Sneks"
+        await self.send_random_image(inter, subreddit, "s  n  e  k")
+
+    @commands.cooldown(1, 2)
     @commands.command(description="Send a random snek image.")
     async def snek(self, ctx):
         subreddit = "Sneks"
         await self.send_random_image(ctx, subreddit, "s  n  e  k")
+
+    @commands.cooldown(1, 2)
+    @commands.slash_command(name="doggo", description="Send a random doggo image.")
+    async def _doggo(self, inter):
+        await inter.response.defer()
+        subreddit = random.choice(["dog", "dogpictures", "puppies", "PuppySmiles"])
+        await self.send_random_image(inter, subreddit, "Here, have a doggo!")
 
     @commands.cooldown(1, 2)
     @commands.command(description="Send a random doggo image.")

--- a/src/cogs/utility.py
+++ b/src/cogs/utility.py
@@ -257,9 +257,8 @@ class Utility(commands.Cog):
     async def botinfo(self, ctx):
         app_info = await self.bot.application_info()
         owner = app_info.owner
-        me = ctx.me
+        me = self.bot.user
         bot_age = td_format(disnake.utils.utcnow() - me.created_at, hide_seconds=True)
-        server_prefix = await db_servers.get_prefix(self.bot, ctx)
         # get some bot stats
         guild_count = len(self.bot.guilds)
         commands_count = len(self.bot.commands)
@@ -294,7 +293,7 @@ class Utility(commands.Cog):
         for i, command in enumerate(top_commands_array):
             command_name = command["command_name"]
             usage = format_number(command["usage"])
-            top_commands += "{}) `>{}` | used **{}** times (**{}%**)\n".format(
+            top_commands += "{}) `{}` | used **{}** times (**{}%**)\n".format(
                 i + 1,
                 command_name,
                 usage,
@@ -334,7 +333,7 @@ class Utility(commands.Cog):
         user_info = f"• You have used this bot **{user_usage_count}** times!\n"
         user_info += f"• Your user rank is: **{user_usage_rank}**"
         if most_used_command:
-            user_info += "\n• Your most used command is `>{}` with **{}** uses, that's **{}%** of your total uses.".format(
+            user_info += "\n• Your most used command is `{}` with **{}** uses, that's **{}%** of your total uses.".format(
                 most_used_command[0]["command_name"],
                 most_used_command[0]["usage"],
                 format_number(
@@ -348,8 +347,7 @@ class Utility(commands.Cog):
         embed.description += (
             f"Bot version: `{VERSION}` - Ping: `{round(self.bot.latency*1000,2)} ms`\n"
         )
-        embed.description += f"Bot age: {bot_age}\n"
-        embed.description += f"Server prefix: `{server_prefix}`"
+        embed.description += f"Bot age: {bot_age}"
         embed.add_field(name="**Bot Stats**", value=stats, inline=False)
         embed.add_field(
             name=f"**Top {len(top_commands_array)} Commands**",

--- a/src/cogs/utility.py
+++ b/src/cogs/utility.py
@@ -1,7 +1,7 @@
 import platform
 import time
-from sys import exit
 from datetime import datetime, timedelta, timezone
+from sys import exit
 
 import disnake
 from disnake.ext import commands
@@ -43,18 +43,6 @@ class Utility(commands.Cog):
     @commands.command(description="pong! (show the bot latency)")
     async def ping(self, ctx):
         await ctx.send(f"pong! (bot latency: `{round(self.bot.latency*1000,2)}` ms)")
-
-    @commands.command(usage="[prefix]", description="Change or display the bot prefix.")
-    @commands.check_any(
-        commands.is_owner(), commands.has_permissions(administrator=True)
-    )
-    async def prefix(self, ctx, prefix=None):
-        if prefix is None:
-            prefix = ctx.prefix
-            await ctx.send("Current prefix: `" + prefix + "`")
-        else:
-            await db_servers.update_prefix(prefix, ctx.guild.id)
-            await ctx.send(":white_check_mark: Prefix set to `" + prefix + "`")
 
     choices = ["years", "months", "weeks", "days", "hours", "minutes", "seconds"]
 
@@ -264,7 +252,8 @@ class Utility(commands.Cog):
     @commands.command(
         name="botinfo",
         aliases=["binfo"],
-        description="Show some stats and information about the bot.")
+        description="Show some stats and information about the bot.",
+    )
     async def botinfo(self, ctx):
         app_info = await self.bot.application_info()
         owner = app_info.owner
@@ -624,9 +613,7 @@ class Utility(commands.Cog):
                 return await ctx.send(f":x: {e}")
         guild_name = guild.name
         guild_id = guild.id
-        return await ctx.send(
-            f"ID `{guild_id}` returns **{guild_name}**"
-        )
+        return await ctx.send(f"ID `{guild_id}` returns **{guild_name}**")
 
     @commands.command(
         name="serverlist",

--- a/src/cogs/utility.py
+++ b/src/cogs/utility.py
@@ -111,15 +111,18 @@ class Utility(commands.Cog):
 
         await ctx.send(f"{str_to_td(input,raw=True)} = {res}.")
 
-    @commands.command(hidden=True)
-    @commands.is_owner()
-    async def rl(self, ctx, extension):
+    async def _do_reload(self, ctx, extension):
         try:
             self.bot.reload_extension("cogs." + extension)
         except Exception as e:
             return await ctx.send("```:x: {}: {} ```".format(type(e).__name__, e))
 
         await ctx.send(f":white_check_mark: Extension `{extension}` has been reloaded")
+
+    @commands.command(hidden=True)
+    @commands.is_owner()
+    async def rl(self, ctx, extension):
+        await self._do_reload(ctx, extension)
 
     @commands.slash_command(name="time")
     async def _time(self, inter: disnake.AppCmdInter, timezone: str = None):
@@ -192,7 +195,15 @@ class Utility(commands.Cog):
         await self.sql(ctx, sql_expression=sql_expression, as_text=True)
 
     async def sql(self, ctx, *, sql_expression, as_text=True):
-        async with ctx.typing():
+        # slash interactions have no `.typing()` (they're deferred by the caller instead)
+        if isinstance(ctx, commands.Context):
+            async with ctx.typing():
+                start = time.time()
+                try:
+                    rows = await db_servers.db.sql_select(sql_expression)
+                except Exception as e:
+                    return await ctx.send(f":x: SQL error: ```{e}```")
+        else:
             start = time.time()
             try:
                 rows = await db_servers.db.sql_select(sql_expression)
@@ -231,21 +242,34 @@ class Utility(commands.Cog):
             file = await image_to_file(img, "table.png", embed)
             return await ctx.send(file=file, embed=embed)
 
-    @commands.command(hidden=True, usage="<sql expression>")
-    @commands.is_owner()
-    async def sqlcommit(self, ctx, *, sql_expression):
-        async with ctx.typing():
+    async def _do_sqlcommit(self, ctx, sql_expression):
+        # slash interactions have no `.typing()` (they're deferred by the caller instead)
+        if isinstance(ctx, commands.Context):
+            async with ctx.typing():
+                try:
+                    nb_lines = await db_servers.db.sql_update(sql_expression)
+                except Exception as e:
+                    return await ctx.send(f":x: SQL error: ```{e}```")
+        else:
             try:
                 nb_lines = await db_servers.db.sql_update(sql_expression)
             except Exception as e:
                 return await ctx.send(f":x: SQL error: ```{e}```")
         return await ctx.send(f"Done! ({nb_lines} lines affected)")
 
+    @commands.command(hidden=True, usage="<sql expression>")
+    @commands.is_owner()
+    async def sqlcommit(self, ctx, *, sql_expression):
+        await self._do_sqlcommit(ctx, sql_expression)
+
+    async def _do_restart(self, ctx):
+        await ctx.send("Restarting now...")
+        exit()
+
     @commands.command(hidden=True)
     @commands.is_owner()
     async def restart(self, ctx):
-        await ctx.send("Restarting now...")
-        exit()
+        await self._do_restart(ctx)
 
     @commands.slash_command(name="botinfo")
     async def _botinfo(self, inter: disnake.AppCmdInter):
@@ -574,14 +598,7 @@ class Utility(commands.Cog):
         embed.timestamp = dt
         await ctx.send(embed=embed)
 
-    @commands.command(
-        name="leave",
-        description="Make the bot leave a server. (owner only)",
-        hidden=True,
-        usage="<server ID>",
-    )
-    @commands.is_owner()
-    async def leave(self, ctx, guild_id):
+    async def _do_leave(self, ctx, guild_id):
         guild = self.bot.get_guild(guild_id)
         if guild is None:
             try:
@@ -599,13 +616,16 @@ class Utility(commands.Cog):
         )
 
     @commands.command(
-        name="verify",
-        description="Verify a server ID and get its name. (owner only)",
+        name="leave",
+        description="Make the bot leave a server. (owner only)",
         hidden=True,
         usage="<server ID>",
     )
     @commands.is_owner()
-    async def verify(self, ctx, guild_id):
+    async def leave(self, ctx, guild_id):
+        await self._do_leave(ctx, guild_id)
+
+    async def _do_verify(self, ctx, guild_id):
         guild = self.bot.get_guild(guild_id)
         if guild is None:
             try:
@@ -617,12 +637,16 @@ class Utility(commands.Cog):
         return await ctx.send(f"ID `{guild_id}` returns **{guild_name}**")
 
     @commands.command(
-        name="serverlist",
-        description="Show the list of servers the bot is in. (owner only)",
+        name="verify",
+        description="Verify a server ID and get its name. (owner only)",
         hidden=True,
+        usage="<server ID>",
     )
     @commands.is_owner()
-    async def serverlist(self, ctx):
+    async def verify(self, ctx, guild_id):
+        await self._do_verify(ctx, guild_id)
+
+    async def _do_serverlist(self, ctx):
         sql = """
             SELECT
                 server_name,
@@ -689,6 +713,112 @@ class Utility(commands.Cog):
 
         view = ServerPagesView(ctx.author, embeds=embeds)
         await ctx.send(embed=embeds[0], view=view)
+
+    @commands.command(
+        name="serverlist",
+        description="Show the list of servers the bot is in. (owner only)",
+        hidden=True,
+    )
+    @commands.is_owner()
+    async def serverlist(self, ctx):
+        await self._do_serverlist(ctx)
+
+    # --- /owner slash group ---
+
+    @commands.slash_command(
+        name="owner",
+        default_member_permissions=disnake.Permissions(administrator=True),
+    )
+    async def _owner(self, inter: disnake.AppCmdInter):
+        pass
+
+    @_owner.sub_command(name="reload", description="Reload an extension. (owner only)")
+    @commands.is_owner()
+    async def _owner_reload(self, inter: disnake.AppCmdInter, extension: str):
+        """Reload an extension. (owner only)
+
+        Parameters
+        ----------
+        extension: The name of the extension (cog) to reload."""
+        await self._do_reload(inter, extension)
+
+    @_owner.sub_command(name="sql", description="Run a read-only SQL query. (owner only)")
+    @commands.is_owner()
+    async def _owner_sql(self, inter: disnake.AppCmdInter, expression: str):
+        """Run a read-only SQL query and show the result as an image. (owner only)
+
+        Parameters
+        ----------
+        expression: The SQL expression to run."""
+        await inter.response.defer()
+        await self.sql(inter, sql_expression=expression, as_text=False)
+
+    @_owner.sub_command(
+        name="sqltext", description="Run a read-only SQL query. (owner only)"
+    )
+    @commands.is_owner()
+    async def _owner_sqltext(self, inter: disnake.AppCmdInter, expression: str):
+        """Run a read-only SQL query and show the result as text. (owner only)
+
+        Parameters
+        ----------
+        expression: The SQL expression to run."""
+        await inter.response.defer()
+        await self.sql(inter, sql_expression=expression, as_text=True)
+
+    @_owner.sub_command(
+        name="sqlcommit", description="Run a write SQL query. (owner only)"
+    )
+    @commands.is_owner()
+    async def _owner_sqlcommit(self, inter: disnake.AppCmdInter, expression: str):
+        """Run a write (INSERT/UPDATE/DELETE) SQL query. (owner only)
+
+        Parameters
+        ----------
+        expression: The SQL expression to run."""
+        await inter.response.defer()
+        await self._do_sqlcommit(inter, expression)
+
+    @_owner.sub_command(name="restart", description="Restart the bot. (owner only)")
+    @commands.is_owner()
+    async def _owner_restart(self, inter: disnake.AppCmdInter):
+        """Restart the bot. (owner only)"""
+        await self._do_restart(inter)
+
+    @_owner.sub_command(
+        name="leave", description="Make the bot leave a server. (owner only)"
+    )
+    @commands.is_owner()
+    async def _owner_leave(self, inter: disnake.AppCmdInter, guild_id: str):
+        """Make the bot leave a server. (owner only)
+
+        Parameters
+        ----------
+        guild_id: The ID of the server to leave."""
+        await inter.response.defer()
+        await self._do_leave(inter, guild_id)
+
+    @_owner.sub_command(
+        name="verify", description="Verify a server ID and get its name. (owner only)"
+    )
+    @commands.is_owner()
+    async def _owner_verify(self, inter: disnake.AppCmdInter, guild_id: str):
+        """Verify a server ID and get its name. (owner only)
+
+        Parameters
+        ----------
+        guild_id: The ID of the server to verify."""
+        await inter.response.defer()
+        await self._do_verify(inter, guild_id)
+
+    @_owner.sub_command(
+        name="serverlist",
+        description="Show the list of servers the bot is in. (owner only)",
+    )
+    @commands.is_owner()
+    async def _owner_serverlist(self, inter: disnake.AppCmdInter):
+        """Show the list of servers the bot is in. (owner only)"""
+        await self._do_serverlist(inter)
 
     # Populate the snapshot database with snapshot URLs sent in the snapshots channel
     # (This is meant to be used only once)

--- a/src/cogs/utility.py
+++ b/src/cogs/utility.py
@@ -16,6 +16,7 @@ from utils.discord_utils import (
     UserConverter,
     format_number,
     format_table,
+    get_display_prefix,
     get_image_url,
     image_to_file,
 )
@@ -155,7 +156,9 @@ class Utility(commands.Cog):
             if timezone is None:
                 err_msg = (
                     ":x: You haven't set your timezone!\n(use `{}{} <timezone>`)".format(
-                        ctx.prefix if isinstance(ctx, commands.Context) else "/",
+                        get_display_prefix(self.bot)
+                        if isinstance(ctx, commands.Context)
+                        else "/",
                         "settimezone"
                         if isinstance(ctx, commands.Context)
                         else "user settimezone",

--- a/src/cogs/utility.py
+++ b/src/cogs/utility.py
@@ -740,6 +740,7 @@ class Utility(commands.Cog):
         Parameters
         ----------
         extension: The name of the extension (cog) to reload."""
+        await inter.response.defer()
         await self._do_reload(inter, extension)
 
     @_owner.sub_command(name="sql", description="Run a read-only SQL query. (owner only)")
@@ -818,6 +819,7 @@ class Utility(commands.Cog):
     @commands.is_owner()
     async def _owner_serverlist(self, inter: disnake.AppCmdInter):
         """Show the list of servers the bot is in. (owner only)"""
+        await inter.response.defer()
         await self._do_serverlist(inter)
 
     # Populate the snapshot database with snapshot URLs sent in the snapshots channel

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ from datetime import timezone
 import disnake
 from disnake.ext import commands
 from dotenv import load_dotenv
+
 load_dotenv()
 
 from utils.log import close_loggers, get_logger, setup_loggers
@@ -23,7 +24,7 @@ from utils.setup import (
 intents = disnake.Intents.default()
 intents.members = False
 intents.presences = False
-intents.message_content = True
+intents.message_content = False
 activity = disnake.Activity(
     type=disnake.ActivityType.watching, name="Watching you place those pixels 👀"
 )
@@ -37,7 +38,7 @@ fetch_owner_ids = os.getenv("OWNER_IDS", "").strip()
 if fetch_owner_ids:
     owner_ids = {int(x) for x in fetch_owner_ids.split(",") if x}
     bot = commands.Bot(
-        command_prefix=db_servers.get_prefix,
+        command_prefix=commands.when_mentioned,
         help_command=None,
         intents=intents,
         case_insensitive=True,
@@ -45,11 +46,11 @@ if fetch_owner_ids:
         test_guilds=GUILD_IDS,
         reload=bool(GUILD_IDS),
         allowed_mentions=allowed_mentions,
-        owner_ids=owner_ids
+        owner_ids=owner_ids,
     )
 else:
     bot = commands.Bot(
-        command_prefix=db_servers.get_prefix,
+        command_prefix=commands.when_mentioned,
         help_command=None,
         intents=intents,
         case_insensitive=True,
@@ -372,24 +373,25 @@ async def on_message(message):
                     return
 
     try:
-        if message.content == ">_>":
-            return await message.channel.send("<_<")
-        if message.content == ">.>":
-            return await message.channel.send("<.<")
-        if message.content == ">_<":
-            return await message.channel.send("<_>")
-        if message.content == "aa":
-            await message.channel.send("<:watermeloneat:955627387666694155>")
-        if message.content == "AA":
-            await message.channel.send("<:watermelonDEATH:949447275753648268>")
-    except Exception:
-        pass
-
-    try:
         if bot.user in message.mentions:
-            if "good bot" in message.content.lower():
+            # content after stripping the leading mention(s)
+            content = message.content
+            for mention in (bot.user.mention, f"<@!{bot.user.id}>"):
+                content = content.replace(mention, "", 1)
+            content = content.strip()
+
+            egg_replies = {">_>": "<_<", ">.>": "<.<", ">_<": "<_>"}
+            egg_reactions = {
+                "aa": "<:watermeloneat:955627387666694155>",
+                "AA": "<:watermelonDEATH:949447275753648268>",
+            }
+            if content in egg_replies:
+                return await message.channel.send(egg_replies[content])
+            if content in egg_reactions:
+                await message.channel.send(egg_reactions[content])
+            elif "good bot" in content.lower():
                 await message.add_reaction("<a:GoodBot:955658963171565658>")
-            elif "bad bot" in message.content.lower():
+            elif "bad bot" in content.lower():
                 await message.add_reaction("<a:BadBot:955659116506935336>")
             else:
                 await message.add_reaction("<:peepoPinged:943594603632816188>")
@@ -413,7 +415,10 @@ async def on_guild_join(guild: disnake.Guild):
         return
 
     if GUILD_MEMBER_MIN and guild.member_count < GUILD_MEMBER_MIN:
-        general_channel = next((channel for channel in guild.text_channels if channel.name == 'general'), None)
+        general_channel = next(
+            (channel for channel in guild.text_channels if channel.name == "general"),
+            None,
+        )
         target_channel = None
         if general_channel and general_channel.permissions_for(guild.me).send_messages:
             target_channel = general_channel
@@ -422,10 +427,14 @@ async def on_guild_join(guild: disnake.Guild):
                 if channel.permissions_for(guild.me).send_messages:
                     target_channel = channel
                     break
-        
+
         if target_channel:
-            await target_channel.send("Due to the 100 server limit, using Clueless is not supported in guilds below {0} members. Please refer to the DMs for personal use.".format(GUILD_MEMBER_MIN))
-        
+            await target_channel.send(
+                "Due to the 100 server limit, using Clueless is not supported in guilds below {0} members. Please refer to the DMs for personal use.".format(
+                    GUILD_MEMBER_MIN
+                )
+            )
+
         await guild.leave()
         return
 
@@ -447,7 +456,10 @@ async def on_guild_join(guild: disnake.Guild):
         timestamp=guild.created_at,
     )
     embed.add_field(name="**Server Name**", value=guild.name)
-    embed.add_field(name="**Owner**", value=f"<@{guild.owner_id}> ({guild.owner if guild.owner else 'Unknown'})")
+    embed.add_field(
+        name="**Owner**",
+        value=f"<@{guild.owner_id}> ({guild.owner if guild.owner else 'Unknown'})",
+    )
     embed.add_field(name="**Members**", value=guild.member_count)
     if guild.icon:
         embed.set_thumbnail(url=guild.icon.url)
@@ -475,7 +487,10 @@ async def on_guild_remove(guild):
         timestamp=guild.created_at,
     )
     embed.add_field(name="**Server Name**", value=guild.name)
-    embed.add_field(name="**Owner**", value=f"<@{guild.owner_id}> ({guild.owner if guild.owner else 'Unknown'})")
+    embed.add_field(
+        name="**Owner**",
+        value=f"<@{guild.owner_id}> ({guild.owner if guild.owner else 'Unknown'})",
+    )
     embed.add_field(name="**Members**", value=guild.member_count)
     if guild.icon:
         embed.set_thumbnail(url=guild.icon.url)

--- a/src/main.py
+++ b/src/main.py
@@ -212,8 +212,13 @@ async def on_command_error(ctx, error):
 
     # handled errors
     if not slash_command and isinstance(error, commands.MissingRequiredArgument):
+        # local import: utils.discord_utils imports `tracked_templates` from this
+        # module, so importing it at module level here would create a circular
+        # import during startup.
+        from utils.discord_utils import get_display_prefix
+
         text = ":x: " + str(error) + "\n"
-        text += f"Usage: `{ctx.prefix}{command_name} {ctx.command.usage}`"
+        text += f"Usage: `{get_display_prefix(bot)}{command_name} {ctx.command.usage}`"
         return await ctx.send(text)
 
     if isinstance(error, (commands.MissingPermissions, commands.NotOwner)):
@@ -393,7 +398,7 @@ async def on_message(message):
                 await message.add_reaction("<a:GoodBot:955658963171565658>")
             elif "bad bot" in content.lower():
                 await message.add_reaction("<a:BadBot:955659116506935336>")
-            else:
+            elif not content:
                 await message.add_reaction("<:peepoPinged:943594603632816188>")
     except Exception:
         pass

--- a/src/utils/discord_utils.py
+++ b/src/utils/discord_utils.py
@@ -410,18 +410,17 @@ class UserConverter(commands.Converter):
 
 
 async def get_embed_author(inter: disnake.MessageInteraction) -> disnake.User:
-    """Get the author User from an embed if it has "Requested by name#0000" in the footer,
+    """Get the author User from an embed footer "Requested by <username>",
     return ``None`` if not found."""
     embeds = inter.message.embeds
     if not embeds:
         return None
     try:
-        found = re.findall(r"Requested by (.*)#([0-9]{4})", embeds[0].footer.text)
+        found = re.search(r"Requested by (.+)", embeds[0].footer.text)
         if not found:
             return None
-        name = found[0][0]
-        discrim = found[0][1]
-        predicate = lambda u: u.name == name and u.discriminator == discrim  # noqa: E731
+        name = found.group(1).strip()
+        predicate = lambda u: str(u) == name or u.name == name  # noqa: E731
         result = disnake.utils.find(predicate, inter.bot.users)
         return result
     except Exception:

--- a/src/utils/discord_utils.py
+++ b/src/utils/discord_utils.py
@@ -409,6 +409,11 @@ class UserConverter(commands.Converter):
             raise commands.UserNotFound(argument)
 
 
+def get_display_prefix(bot) -> str:
+    """User-facing prefix shown in command usage/error copy (mention dispatch)."""
+    return f"@{bot.user.name} "
+
+
 async def get_embed_author(inter: disnake.MessageInteraction) -> disnake.User:
     """Get the author User from an embed footer "Requested by <username>",
     return ``None`` if not found."""

--- a/src/utils/image/s3compat.py
+++ b/src/utils/image/s3compat.py
@@ -1,10 +1,10 @@
+import hashlib
 import json
 import os
 from io import BytesIO
-import hashlib
 
-from botocore.exceptions import ClientError
 import boto3
+from botocore.exceptions import ClientError
 from dotenv import find_dotenv, load_dotenv, set_key
 from PIL import Image
 
@@ -16,7 +16,9 @@ SIZE_LIMIT = 5 * 2**20  # 5 MB
 
 
 class S3Compat:
-    def __init__(self, access_key, secret_key, endpoint_url, bucket_name, access_url = None):
+    def __init__(
+        self, access_key, secret_key, endpoint_url, bucket_name, access_url=None
+    ):
         self.access_key = access_key
         self.secret_key = secret_key
         self.endpoint_url = endpoint_url
@@ -33,26 +35,28 @@ class S3Compat:
             payload_image = image
 
         # Generate hash from image content
-        image_hash = hashlib.sha256(payload_image).hexdigest()[:16]  # Adjust the length as needed
+        image_hash = hashlib.sha256(payload_image).hexdigest()[
+            :16
+        ]  # Adjust the length as needed
 
         # Create S3 client
         s3_client = boto3.client(
-            's3',
+            "s3",
             aws_access_key_id=self.access_key,
             aws_secret_access_key=self.secret_key,
-            endpoint_url=self.endpoint_url
+            endpoint_url=self.endpoint_url,
         )
 
         # Upload image
-        filename = f'{image_hash}.png'
+        filename = f"{image_hash}.png"
         try:
             metadata = custom_metadata if custom_metadata else {}
             response = s3_client.put_object(
                 Bucket=self.bucket_name,
                 Key=filename,
                 Body=payload_image,
-                ContentType='image/png',
-                Metadata=metadata
+                ContentType="image/png",
+                Metadata=metadata,
             )
         except ClientError as e:
             print(f"Error uploading image: {e}")
@@ -60,13 +64,14 @@ class S3Compat:
             raise  # Re-raise the exception if necessary
 
         # Get the image URL
-        if self.access_url:
-            image_url = f"{self.access_url}/{filename}"
-        else:
-            image_url = f"{self.access_url}/{self.bucket_name}/{filename}"
+        if not self.access_url:
+            raise ValueError(
+                "S3_COMPAT_ACCESS_URL is not configured; cannot build a stable image URL."
+            )
+        image_url = f"{self.access_url}/{filename}"
 
         return image_url
-    
+
     @in_executor()
     def image_to_bytes(self, image: Image.Image, format="PNG"):
         """converts PIL.Image -> bytes"""


### PR DESCRIPTION
## Summary

This migrates the bot off the privileged **`message_content`** intent. Instead of removing text commands, it switches how they're triggered: from a text prefix to an **@mention**. Discord still delivers message content for messages that mention the bot (as well as DMs and replies), so every existing prefix command keeps working as `@Clueless <command>`. To make the two interfaces interchangeable, this also adds slash equivalents for every remaining prefix-only command, so **each command is now usable both as a slash command and as a mention command**. A few bug fixes and a snapshot-storage fix that surfaced along the way are included.

Closes #24 #32 

## Why

The `message_content` intent is privileged. It gates the bot at 10,000 users and it isn't actually needed here. Discord delivers message content without it in three cases: messages that **@mention the bot**, DMs to the bot, and replies with ping. Dispatching commands by mention lets us drop the intent while keeping the full text-command experience.

## What changed

### Intent and dispatch
- Set `intents.message_content = False`.
- Changed `command_prefix` to `commands.when_mentioned`. Text commands are now invoked as `@Clueless help`, `@Clueless temp <image>`, and so on.
- Removed the `>prefix` command. The per-server prefix column is left dormant, with no schema migration.
- Easter eggs (`>_>`, `aa`, `good bot`/`bad bot`) now trigger via @mention.
- `/help` and the usage/error copy across the cogs now render `@BotName ...` instead of the old `>` prefix.

### Command parity (new slash commands)
- Fun and utility: `/kitten`, `/duck`, `/bird`, `/snek`, `/doggo`, `/fonts`, `/styles`
- Moderation: `/blacklist` (add/remove/list), `/roleblacklist` (add/remove)
- Admin: `/emote` (add/remove/list/number), `/setsnapshots` (channel/disable)
- Owner: `/owner` group (reload/sql/sqltext/sqlcommit/restart/leave/verify/serverlist), `/forceupdate`, `/progress reload-admins`
- `/progress manager add` and `/progress manager delete` now accept multiple users per call, matching the prefix versions

Each new slash command delegates to the same shared helper as its prefix twin, so behaviour is identical across both interfaces. Owner commands are gated with `@commands.is_owner()` (backed by `OWNER_IDS`), and admin commands carry per-subcommand permission checks.

### Bug fixes
- **`/botinfo`** crashed on slash invocation because `ctx.me` was `None`. It now uses `self.bot.user`.
- **`get_embed_author`** assumed the legacy `name#1234` discriminator, so `/help` buttons rejected the invoker under the new username system. It now matches discriminator-less usernames.
- **`roleblacklist` permission hole:** the prefix `roleblacklist add`/`remove` subcommands were effectively ungated, because the parent group used `invoke_without_command=True`, which skips the group's check. Each subcommand now carries its own `is_owner`/`manage_roles` check, on both the prefix and slash sides.
- **SQL/interaction crash:** the shared `sql()` helper used `async with ctx.typing()` unconditionally, which raises `AttributeError` on an interaction. It's now guarded by context type.
- Slash commands that do network, DB, or import work now `defer()` before their first response, to avoid the 3 second interaction-token expiry.

### Snapshot storage
- `send_snapshots` stored Discord CDN URLs, which expire after about 24 hours and broke `/snapshot` and `/timelapse`. It now uploads the snapshot to S3/R2 via the existing `S3Compat` helper and stores a stable URL.
- `S3Compat.upload_image` now fails loudly (raises) when `S3_COMPAT_ACCESS_URL` is unset, instead of silently building a broken `None/...` URL. All callers (`/snapshot`, `/template`, `/layer`) handle the failure gracefully.

## Behaviour and breaking changes
- Text commands now need an **@mention** in normal channels (`@Clueless help`). The bare `>` prefix no longer works in channels, because Discord doesn't deliver content there without the intent. It still works in DMs and replies. The `>prefix` command and per-server custom prefix are removed.

## Config and deploy notes
- Requires the `OWNER_IDS` env var (comma-separated) for owner-command gating.
- Requires `S3_COMPAT_ACCESS_URL` (and the other `S3_COMPAT_*` vars) for snapshot, template, and layer image hosting.
- Only `message_content` is being dropped. `members` and `presences` were already off. Turn `message_content` off in the developer portal after deploy.